### PR TITLE
feat: DApp ENS integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `abi` directory to the `@cartesi/rollups` package, ideal for language bindings.
+- ENS integration, allows DApp to set its name in the ENS reverse registry
 
 ### Removed
 

--- a/onchain/rollups/contracts/dapp/CartesiDAppFactory.sol
+++ b/onchain/rollups/contracts/dapp/CartesiDAppFactory.sol
@@ -3,6 +3,7 @@
 
 pragma solidity ^0.8.8;
 
+import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 import {ICartesiDAppFactory} from "./ICartesiDAppFactory.sol";
@@ -12,6 +13,12 @@ import {CartesiDApp} from "./CartesiDApp.sol";
 /// @title Cartesi DApp Factory
 /// @notice Allows anyone to reliably deploy a new `CartesiDApp` contract.
 contract CartesiDAppFactory is ICartesiDAppFactory {
+    ENS public immutable ens;
+
+    constructor(ENS _ens) {
+        ens = _ens;
+    }
+
     function newApplication(
         IConsensus _consensus,
         address _dappOwner,
@@ -19,6 +26,7 @@ contract CartesiDAppFactory is ICartesiDAppFactory {
     ) external override returns (CartesiDApp) {
         CartesiDApp application = new CartesiDApp(
             _consensus,
+            ens,
             _dappOwner,
             _templateHash
         );
@@ -41,6 +49,7 @@ contract CartesiDAppFactory is ICartesiDAppFactory {
     ) external override returns (CartesiDApp) {
         CartesiDApp application = new CartesiDApp{salt: _salt}(
             _consensus,
+            ens,
             _dappOwner,
             _templateHash
         );
@@ -67,7 +76,7 @@ contract CartesiDAppFactory is ICartesiDAppFactory {
                 keccak256(
                     abi.encodePacked(
                         type(CartesiDApp).creationCode,
-                        abi.encode(_consensus, _dappOwner, _templateHash)
+                        abi.encode(_consensus, ens, _dappOwner, _templateHash)
                     )
                 )
             );

--- a/onchain/rollups/contracts/dapp/ICartesiDApp.sol
+++ b/onchain/rollups/contracts/dapp/ICartesiDApp.sol
@@ -6,6 +6,8 @@ pragma solidity ^0.8.8;
 import {IConsensus} from "../consensus/IConsensus.sol";
 import {OutputValidityProof} from "../library/LibOutputValidation.sol";
 
+import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
+
 /// @notice Data for validating outputs.
 /// @param validity A validity proof for the output
 /// @param context Data for querying the right claim from the current consensus contract
@@ -80,4 +82,16 @@ interface ICartesiDApp {
     /// @notice Get the current consensus.
     /// @return The current consensus
     function getConsensus() external view returns (IConsensus);
+
+    /// @notice Get the ENS registry used to set the `name()` record for the
+    /// reverse ENS record associated with the DApp contract.
+    /// @return The ENS registry.
+    function ens() external returns (ENS);
+
+    // @notice Sets the `name()` record for the reverse ENS record associated with
+    // the DApp contract. First updates the resolver to the default reverse
+    // resolver if necessary.
+    // @param name The name to set for the DApp contract address
+    // @return The ENS node hash of the reverse record
+    function setName(string memory _name) external returns (bytes32);
 }

--- a/onchain/rollups/contracts/dapp/ICartesiDAppFactory.sol
+++ b/onchain/rollups/contracts/dapp/ICartesiDAppFactory.sol
@@ -6,6 +6,8 @@ pragma solidity ^0.8.8;
 import {CartesiDApp} from "./CartesiDApp.sol";
 import {IConsensus} from "../consensus/IConsensus.sol";
 
+import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
+
 /// @title Cartesi DApp Factory interface
 interface ICartesiDAppFactory {
     // Events
@@ -65,4 +67,9 @@ interface ICartesiDAppFactory {
         bytes32 _templateHash,
         bytes32 _salt
     ) external view returns (address);
+
+    /// @notice Get the ENS registry used to set the `name()` record for the
+    /// reverse ENS record associated with the DApp contracts deployed by this factory.
+    /// @return The ENS registry.
+    function ens() external returns (ENS);
 }

--- a/onchain/rollups/deploy/02_factory.ts
+++ b/onchain/rollups/deploy/02_factory.ts
@@ -3,10 +3,19 @@
 
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction, DeployOptions } from "hardhat-deploy/types";
+import { deployENS, ENS } from "@ethereum-waffle/ens";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+const deployEns = async (deployer: SignerWithAddress) => {
+    const ens = await deployENS(deployer);
+    await ens.createTopLevelDomain("test");
+    return ens.ens.address;
+};
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
-    const { deployments, getNamedAccounts, network } = hre;
+    const { deployments, getNamedAccounts, ethers, network } = hre;
     const { deployer } = await getNamedAccounts();
+    const [deployerSigner] = await ethers.getSigners();
 
     // IoTeX doesn't have support yet, see https://github.com/safe-global/safe-singleton-factory/issues/199
     // Chiado is not working, see https://github.com/safe-global/safe-singleton-factory/issues/201
@@ -23,8 +32,13 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
     const { Bitmask, MerkleV2 } = await deployments.all();
 
+    // ENS
+    const provider = ethers.getDefaultProvider();
+    const ensAddress = provider.network.ensAddress || deployEns(deployerSigner);
+
     await deployments.deploy("CartesiDAppFactory", {
         ...opts,
+        args: [ensAddress],
         libraries: {
             Bitmask: Bitmask.address,
             MerkleV2: MerkleV2.address,

--- a/onchain/rollups/package.json
+++ b/onchain/rollups/package.json
@@ -32,9 +32,11 @@
     },
     "dependencies": {
         "@cartesi/util": "6.0.0",
+        "@ensdomains/ens-contracts": "0.0.22",
         "@openzeppelin/contracts": "4.9.2"
     },
     "devDependencies": {
+        "@ethereum-waffle/ens": "^4.0.3",
         "@ethersproject/abi": "^5",
         "@ethersproject/bytes": "^5",
         "@ethersproject/providers": "^5",

--- a/onchain/rollups/remappings.txt
+++ b/onchain/rollups/remappings.txt
@@ -1,4 +1,5 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
 @cartesi/=../node_modules/@cartesi/
+@ensdomains/=../node_modules/@ensdomains/
 @openzeppelin/=../node_modules/@openzeppelin/

--- a/onchain/rollups/test/foundry/dapp/CartesiDApp.t.sol
+++ b/onchain/rollups/test/foundry/dapp/CartesiDApp.t.sol
@@ -12,6 +12,7 @@ import {IConsensus} from "contracts/consensus/IConsensus.sol";
 import {OutputValidityProof, LibOutputValidation} from "contracts/library/LibOutputValidation.sol";
 import {OutputEncoding} from "contracts/common/OutputEncoding.sol";
 
+import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
@@ -54,6 +55,7 @@ contract CartesiDAppTest is TestBase {
 
     CartesiDApp dapp;
     IConsensus consensus;
+    ENS ens;
     IERC20 erc20Token;
     IERC721 erc721Token;
     IERC721Receiver erc721Receiver;
@@ -98,7 +100,7 @@ contract CartesiDAppTest is TestBase {
         bytes32 _templateHash
     ) public {
         vm.expectRevert("Ownable: new owner is the zero address");
-        new CartesiDApp(consensus, address(0), _templateHash);
+        new CartesiDApp(consensus, ens, address(0), _templateHash);
     }
 
     function testConstructor(address _owner, bytes32 _templateHash) public {
@@ -115,7 +117,7 @@ contract CartesiDAppTest is TestBase {
         emit OwnershipTransferred(address(this), _owner);
 
         // perform call to constructor
-        dapp = new CartesiDApp(consensus, _owner, _templateHash);
+        dapp = new CartesiDApp(consensus, ens, _owner, _templateHash);
 
         // check set values
         assertEq(address(dapp.getConsensus()), address(consensus));
@@ -549,7 +551,7 @@ contract CartesiDAppTest is TestBase {
         vm.assume(address(_newOwner) != address(0));
         vm.assume(_nonZeroAddress != address(0));
 
-        dapp = new CartesiDApp(consensus, _owner, _templateHash);
+        dapp = new CartesiDApp(consensus, ens, _owner, _templateHash);
 
         IConsensus newConsensus = new SimpleConsensus();
 
@@ -590,7 +592,13 @@ contract CartesiDAppTest is TestBase {
 
     function deployDAppDeterministically() internal returns (CartesiDApp) {
         vm.prank(dappOwner);
-        return new CartesiDApp{salt: salt}(consensus, dappOwner, templateHash);
+        return
+            new CartesiDApp{salt: salt}(
+                consensus,
+                ens,
+                dappOwner,
+                templateHash
+            );
     }
 
     function deployConsensusDeterministically() internal returns (IConsensus) {

--- a/onchain/rollups/test/foundry/dapp/CartesiDAppFactory.t.sol
+++ b/onchain/rollups/test/foundry/dapp/CartesiDAppFactory.t.sol
@@ -4,6 +4,9 @@
 /// @title Cartesi DApp Factory Test
 pragma solidity ^0.8.8;
 
+import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
+import {ENSRegistry} from "@ensdomains/ens-contracts/contracts/registry/ENSRegistry.sol";
+import {PublicResolver} from "@ensdomains/ens-contracts/contracts/resolvers/PublicResolver.sol";
 import {TestBase} from "../util/TestBase.sol";
 import {SimpleConsensus} from "../util/SimpleConsensus.sol";
 import {CartesiDAppFactory} from "contracts/dapp/CartesiDAppFactory.sol";
@@ -13,10 +16,12 @@ import {Vm} from "forge-std/Vm.sol";
 
 contract CartesiDAppFactoryTest is TestBase {
     CartesiDAppFactory factory;
+    ENS ens;
     IConsensus consensus;
 
     function setUp() public {
-        factory = new CartesiDAppFactory();
+        ens = new ENSRegistry();
+        factory = new CartesiDAppFactory(ens);
         consensus = new SimpleConsensus();
     }
 

--- a/onchain/yarn.lock
+++ b/onchain/yarn.lock
@@ -72,6 +72,33 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@ensdomains/buffer@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@ensdomains/buffer/-/buffer-0.1.1.tgz#6c275ba7e457e935405b67876f1f0d980c8baa63"
+  integrity sha512-92SfSiNS8XorgU7OUBHo/i1ZU7JV7iz/6bKuLPNVsMxV79/eI7fJR6jfJJc40zAHjs3ha+Xo965Idomlq3rqnw==
+
+"@ensdomains/ens-contracts@0.0.22":
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@ensdomains/ens-contracts/-/ens-contracts-0.0.22.tgz#a7e9eea3679661a75ddc0a62ab67e6d988cc6769"
+  integrity sha512-kNu7pp68/5KfJ5wkswnUS4NfI9Ek4zGi0nnNSmGf1WXs6BHU9NYRVR6NnoVzb1B+cZ658e1v2srTtvmBYYIYzg==
+  dependencies:
+    "@ensdomains/buffer" "^0.1.1"
+    "@ensdomains/solsha1" "0.0.3"
+    "@openzeppelin/contracts" "^4.1.0"
+    dns-packet "^5.3.0"
+
+"@ensdomains/solsha1@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@ensdomains/solsha1/-/solsha1-0.0.3.tgz#fd479da9d40aadb59ff4fb4ec50632e7d2275a83"
+  integrity sha512-uhuG5LzRt/UJC0Ux83cE2rCKwSleRePoYdQVcqPN1wyf3/ekMzT/KZUF9+v7/AG5w9jlMLCQkUM50vfjr0Yu9Q==
+  dependencies:
+    hash-test-vectors "^1.3.2"
+
+"@ethereum-waffle/ens@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@ethereum-waffle/ens/-/ens-4.0.3.tgz#4a46ac926414f3c83b4e8cc2562c8e2aee06377a"
+  integrity sha512-PVLcdnTbaTfCrfSOrvtlA9Fih73EeDvFS28JQnT5M5P4JMplqmchhcZB1yg/fCtx4cvgHlZXa0+rOCAk2Jk0Jw==
+
 "@ethereumjs/rlp@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@ethereumjs/rlp/-/rlp-4.0.1.tgz#626fabfd9081baab3d0a3074b0c7ecaf674aaa41"
@@ -458,6 +485,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@leichtgewicht/ip-codec@^2.0.1":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
+  integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
+
 "@metamask/eth-sig-util@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz#3ad61f6ea9ad73ba5b19db780d40d9aae5157088"
@@ -736,6 +768,11 @@
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.2.tgz#1cb2d5e4d3360141a17dbc45094a8cad6aac16c1"
   integrity sha512-mO+y6JaqXjWeMh9glYVzVu8HYPGknAAnWyxTRhGeckOruyXQMNnlcW6w/Dx9ftLeIQk6N+ZJFuVmTwF7lEIFrg==
+
+"@openzeppelin/contracts@^4.1.0":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.3.tgz#00d7a8cf35a475b160b3f0293a6403c511099364"
+  integrity sha512-He3LieZ1pP2TNt5JbkPA4PNT9WC3gOTOlDcFGJW4Le4QKqwmiNJCRt44APfxMxvq7OugU/cqYuPcSBzOw38DAg==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -1999,6 +2036,13 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+dns-packet@^5.3.0:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-5.6.1.tgz#ae888ad425a9d1478a0674256ab866de1012cf2f"
+  integrity sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==
+  dependencies:
+    "@leichtgewicht/ip-codec" "^2.0.1"
+
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
@@ -2983,6 +3027,11 @@ hash-base@^3.0.0:
     inherits "^2.0.4"
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
+
+hash-test-vectors@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/hash-test-vectors/-/hash-test-vectors-1.3.2.tgz#f050fde1aff46ec28dcf4f70e4e3238cd5000f4c"
+  integrity sha512-PKd/fitmsrlWGh3OpKbgNLE04ZQZsvs1ZkuLoQpeIKuwx+6CYVNdW6LaPIS1QAdZvV40+skk0w4YomKnViUnvQ==
 
 hash.js@1.1.3:
   version "1.1.3"


### PR DESCRIPTION
This integrates the DApp contract with ENS by allowing the DApp owner to set the name of the DApp.
https://docs.ens.domains/contract-api-reference/reverseregistrar#set-name

It sets the reverse record of the DApp address to a name, allowing a front-end to resolve from address to name.
