### PR TITLE
fix: correct the use of inputIndex in tests

### DIFF
--- a/onchain/rollups/test/foundry/util/LibServerManager.sol
+++ b/onchain/rollups/test/foundry/util/LibServerManager.sol
@@ -173,12 +173,12 @@ library LibServerManager {
     function proves(
         Proof memory p,
         OutputEnum outputEnum,
-        uint256 inputIndex,
+        uint256 inputIndexWithinEpoch,
         uint256 outputIndex
     ) internal pure returns (bool) {
         return
             p.outputEnum == outputEnum &&
-            p.inputIndex == inputIndex &&
+            p.validity.inputIndexWithinEpoch == inputIndexWithinEpoch &&
             p.outputIndex == outputIndex;
     }
 }


### PR DESCRIPTION
- correct the naming of `inputIndex` to `inputIndexWithinEpoch` if it's used incorrectly
- ~~abbreviate `inputIndexWithinEpoch` as `IIWE` if it's compounded with other words~~