### PR TITLE
fix portal tests address overlaps

### DIFF
--- a/onchain/rollups/test/foundry/portals/ERC20Portal.t.sol
+++ b/onchain/rollups/test/foundry/portals/ERC20Portal.t.sol
@@ -304,7 +304,9 @@ contract ERC20PortalHandler is Test {
         if (
             _dapp == address(0) ||
             sender == address(0) ||
-            _dapp == address(this)
+            _dapp == address(this) ||
+            sender == address(portal) ||
+            _dapp == address(portal)
         ) return;
         _amount = bound(_amount, 0, token.balanceOf(address(this)));
 

--- a/onchain/rollups/test/foundry/portals/EtherPortal.t.sol
+++ b/onchain/rollups/test/foundry/portals/EtherPortal.t.sol
@@ -160,6 +160,10 @@ contract EtherPortalHandler is Test {
         _amount = bound(_amount, 0, type(uint128).max);
 
         // fund sender
+        // sender address should not overlap with portal or dapp addresses
+        if (sender == address(portal)) {
+            return;
+        }
         for (uint256 i; i < dapps.length; ++i) {
             if (sender == dapps[i]) {
                 return;


### PR DESCRIPTION
It occurred to me that sometimes github CI tests failed on portal invariant tests like [this one](https://github.com/cartesi/rollups-contracts/actions/runs/6774935288/job/18413093883?pr=121). The reason is that we used `msg.sender` as token sender, and sometimes forge assigns this random `msg.sender` an address that has already deployed a contract (e.g. the portal). This would cause the invariant test to fail because we require portal to have 0 balance all the time.