### PR TITLE
refactor: simplify consensus

### DIFF
--- a/onchain/rollups/contracts/common/InputRange.sol
+++ b/onchain/rollups/contracts/common/InputRange.sol
@@ -4,9 +4,9 @@
 pragma solidity ^0.8.8;
 
 /// @notice A range of input indices.
-/// @param firstInputIndex The index of the first input
-/// @param lastInputIndex The index of the last input
+/// @param firstIndex The index of the first input
+/// @param lastIndex The index of the last input
 struct InputRange {
-    uint256 firstInputIndex;
-    uint256 lastInputIndex;
+    uint256 firstIndex;
+    uint256 lastIndex;
 }

--- a/onchain/rollups/contracts/consensus/AbstractConsensus.sol
+++ b/onchain/rollups/contracts/consensus/AbstractConsensus.sol
@@ -24,7 +24,7 @@ abstract contract AbstractConsensus is IConsensus {
         address dapp,
         InputRange calldata r
     ) public view override returns (bytes32 epochHash) {
-        epochHash = _epochHashes[dapp][r.firstInputIndex][r.lastInputIndex];
+        epochHash = _epochHashes[dapp][r.firstIndex][r.lastIndex];
     }
 
     /// @notice Accept a claim.
@@ -37,7 +37,7 @@ abstract contract AbstractConsensus is IConsensus {
         InputRange calldata r,
         bytes32 epochHash
     ) internal {
-        _epochHashes[dapp][r.firstInputIndex][r.lastInputIndex] = epochHash;
+        _epochHashes[dapp][r.firstIndex][r.lastIndex] = epochHash;
         emit ClaimAcceptance(dapp, r, epochHash);
     }
 }

--- a/onchain/rollups/contracts/consensus/AbstractConsensus.sol
+++ b/onchain/rollups/contracts/consensus/AbstractConsensus.sol
@@ -5,14 +5,11 @@ pragma solidity ^0.8.8;
 
 import {IConsensus} from "./IConsensus.sol";
 import {InputRange} from "../common/InputRange.sol";
-import {LibInputRange} from "../library/LibInputRange.sol";
 
 /// @notice Stores epoch hashes for several DApps and input ranges.
 /// @dev This contract was designed to be inherited by implementations of the `IConsensus` interface
 /// that only need a simple mechanism of storage and retrieval of epoch hashes.
 abstract contract AbstractConsensus is IConsensus {
-    using LibInputRange for InputRange;
-
     /// @notice Indexes epoch hashes by DApp address, first input index and last input index.
     mapping(address => mapping(uint256 => mapping(uint256 => bytes32)))
         private _epochHashes;
@@ -34,16 +31,12 @@ abstract contract AbstractConsensus is IConsensus {
     /// @param dapp The DApp contract address
     /// @param r The input range
     /// @param epochHash The epoch hash
-    /// @dev Raises an `InputRangeIsEmptySet` error if `r` represents the empty set.
     /// @dev On successs, emits a `ClaimAcceptance` event.
     function _acceptClaim(
         address dapp,
         InputRange calldata r,
         bytes32 epochHash
     ) internal {
-        if (r.isEmptySet()) {
-            revert InputRangeIsEmptySet(dapp, r, epochHash);
-        }
         _epochHashes[dapp][r.firstInputIndex][r.lastInputIndex] = epochHash;
         emit ClaimAcceptance(dapp, r, epochHash);
     }

--- a/onchain/rollups/contracts/consensus/IConsensus.sol
+++ b/onchain/rollups/contracts/consensus/IConsensus.sol
@@ -10,7 +10,6 @@ import {InputRange} from "../common/InputRange.sol";
 /// This hash can be later used to prove that any given output was produced by the machine during the epoch.
 /// @notice After an epoch is finalized, a validator may submit a claim containing: the address of the DApp contract,
 /// the range of inputs accepted during the epoch, and the epoch hash.
-/// @notice Input ranges cannot represent the empty set, since at least one input is necessary to advance the state of the machine.
 /// @notice Validators may synchronize epoch finalization, but such mechanism is not specified by this interface.
 /// @notice A validator should be able to save transaction fees by not submitting a claim if it was...
 /// - already submitted by the validator (see the `ClaimSubmission` event) or;
@@ -21,22 +20,11 @@ import {InputRange} from "../common/InputRange.sol";
 /// - submitted by the majority of a quorum or;
 /// - submitted and not proven wrong after some period of time.
 interface IConsensus {
-    /// @notice Tried to submit a claim with an input range that represents the empty set.
-    /// @param inputRange The input range
-    /// @dev An input range represents the empty set if, and only if, the first input index is
-    /// greater than the last input index.
-    error InputRangeIsEmptySet(
-        address dapp,
-        InputRange inputRange,
-        bytes32 epochHash
-    );
-
     /// @notice A claim was submitted to the consensus.
     /// @param submitter The submitter address
     /// @param dapp The DApp contract address
     /// @param inputRange The input range
     /// @param epochHash The epoch hash
-    /// @dev The input range MUST NOT represent the empty set.
     /// @dev Overwrites any previous submissions regarding `submitter`, `dapp` and `inputRange`.
     event ClaimSubmission(
         address indexed submitter,
@@ -49,7 +37,6 @@ interface IConsensus {
     /// @param dapp The DApp contract address
     /// @param inputRange The input range
     /// @param epochHash The epoch hash
-    /// @dev The input range MUST NOT represent the empty set.
     /// @dev MUST be triggered after some `ClaimSubmission` event regarding `dapp`, `inputRange` and `epochHash`.
     /// @dev Overwrites any previous acceptances regarding `dapp` and `inputRange`.
     event ClaimAcceptance(
@@ -62,7 +49,6 @@ interface IConsensus {
     /// @param dapp The DApp contract address
     /// @param inputRange The input range
     /// @param epochHash The epoch hash
-    /// @dev MAY raise an `InputRangeIsEmptySet` error if the input range represents the empty set.
     /// @dev On success, MUST trigger a `ClaimSubmission` event.
     function submitClaim(
         address dapp,

--- a/onchain/rollups/contracts/consensus/authority/Authority.sol
+++ b/onchain/rollups/contracts/consensus/authority/Authority.sol
@@ -20,7 +20,6 @@ contract Authority is AbstractConsensus, Ownable {
     /// @param dapp The DApp contract address
     /// @param inputRange The input range
     /// @param epochHash The epoch hash
-    /// @dev The input range MUST NOT represent the empty set.
     /// @dev On success, triggers a `ClaimSubmission` event and a `ClaimAcceptance` event.
     /// @dev Can only be called by the owner.
     function submitClaim(

--- a/onchain/rollups/contracts/library/LibInputRange.sol
+++ b/onchain/rollups/contracts/library/LibInputRange.sol
@@ -6,13 +6,6 @@ pragma solidity ^0.8.8;
 import {InputRange} from "../common/InputRange.sol";
 
 library LibInputRange {
-    /// @notice Check if an input range represents the empty set.
-    /// @param r The input range
-    /// @return Whether the input range represents the empty set.
-    function isEmptySet(InputRange calldata r) internal pure returns (bool) {
-        return r.firstInputIndex > r.lastInputIndex;
-    }
-
     /// @notice Check if an input range contains an input.
     /// @param r The input range
     /// @param inputIndex The input index

--- a/onchain/rollups/contracts/library/LibInputRange.sol
+++ b/onchain/rollups/contracts/library/LibInputRange.sol
@@ -14,7 +14,6 @@ library LibInputRange {
         InputRange calldata r,
         uint256 inputIndex
     ) internal pure returns (bool) {
-        return
-            r.firstInputIndex <= inputIndex && inputIndex <= r.lastInputIndex;
+        return r.firstIndex <= inputIndex && inputIndex <= r.lastIndex;
     }
 }

--- a/onchain/rollups/contracts/library/LibProof.sol
+++ b/onchain/rollups/contracts/library/LibProof.sol
@@ -10,7 +10,7 @@ library LibProof {
         Proof calldata proof
     ) internal pure returns (uint256 inputIndex) {
         inputIndex =
-            proof.inputRange.firstInputIndex +
+            proof.inputRange.firstIndex +
             proof.validity.inputIndexWithinEpoch;
     }
 }

--- a/onchain/rollups/test/foundry/consensus/authority/Authority.t.sol
+++ b/onchain/rollups/test/foundry/consensus/authority/Authority.t.sol
@@ -71,7 +71,6 @@ contract AuthorityTest is TestBase {
     ) public {
         vm.assume(owner != address(0));
         vm.assume(owner != notOwner);
-        vm.assume(!inputRange.isEmptySet());
 
         Authority authority = new Authority(owner);
 
@@ -86,30 +85,6 @@ contract AuthorityTest is TestBase {
         authority.submitClaim(dapp, inputRange, epochHash);
     }
 
-    function testSubmitClaimRevertsInputRangeIsEmptySet(
-        address owner,
-        address dapp,
-        InputRange calldata inputRange,
-        bytes32 epochHash
-    ) public {
-        vm.assume(owner != address(0));
-        vm.assume(inputRange.isEmptySet());
-
-        Authority authority = new Authority(owner);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IConsensus.InputRangeIsEmptySet.selector,
-                dapp,
-                inputRange,
-                epochHash
-            )
-        );
-
-        vm.prank(owner);
-        authority.submitClaim(dapp, inputRange, epochHash);
-    }
-
     function testSubmitClaim(
         address owner,
         address dapp,
@@ -118,7 +93,6 @@ contract AuthorityTest is TestBase {
         bytes32 epochHash2
     ) public {
         vm.assume(owner != address(0));
-        vm.assume(!inputRange.isEmptySet());
 
         Authority authority = new Authority(owner);
 

--- a/onchain/rollups/test/foundry/dapp/CartesiDApp.t.sol
+++ b/onchain/rollups/test/foundry/dapp/CartesiDApp.t.sol
@@ -376,7 +376,7 @@ contract CartesiDAppTest is TestBase {
         // Here we change the input range artificially to make it look like it ends
         // before the actual input (which is still provable!).
         // The `CartesiDApp` contract, however, will not allow such proof.
-        proof.inputRange.lastInputIndex = inputIndex - 1;
+        proof.inputRange.lastIndex = inputIndex - 1;
         mockConsensus(proof);
 
         vm.expectRevert(

--- a/onchain/rollups/test/foundry/util/LibServerManager.sol
+++ b/onchain/rollups/test/foundry/util/LibServerManager.sol
@@ -176,8 +176,8 @@ library LibServerManager {
     ) internal pure returns (InputRange memory) {
         return
             InputRange({
-                firstInputIndex: getFirstInputIndex(proofs),
-                lastInputIndex: getLastInputIndex(proofs)
+                firstIndex: getFirstInputIndex(proofs),
+                lastIndex: getLastInputIndex(proofs)
             });
     }
 


### PR DESCRIPTION
- rename `{first,last}InputIndex` as `{first,last}Index`: it is clear that the index is about the input because it is a field on the `InputRange` structure, also we save some characters.

- remove empty set check on input range: we don't need to check if the input range is empty or not, because they will be useless to validating outputs anyway, because you can't prove that it contains some input index.