### PR TITLE
bump solc to the latest version 0.8.23

### DIFF
--- a/onchain/rollups/.changeset/quick-months-type.md
+++ b/onchain/rollups/.changeset/quick-months-type.md
@@ -1,5 +1,5 @@
 ---
-"@cartesi/rollups": patch
+"@cartesi/rollups": major
 ---
 
 Bumped Solidity compiler version to 0.8.23.

--- a/onchain/rollups/.changeset/quick-months-type.md
+++ b/onchain/rollups/.changeset/quick-months-type.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": patch
+---
+
+Bumped Solidity compiler version to 0.8.23.

--- a/onchain/rollups/foundry.toml
+++ b/onchain/rollups/foundry.toml
@@ -4,7 +4,7 @@ out = 'out'
 libs = ['node_modules', 'lib']
 test = 'test/foundry'
 cache_path  = 'forge-cache'
-solc_version = '0.8.20'
+solc_version = '0.8.23'
 fs_permissions = [
     { access = "read", path = "./test/foundry/dapp/helper/output/"},
     { access = "read-write", path = "./test/foundry/dapp/helper/input/"}

--- a/onchain/rollups/hardhat.config.ts
+++ b/onchain/rollups/hardhat.config.ts
@@ -64,7 +64,7 @@ const config: HardhatUserConfig = {
         optimism_sepolia: networkConfig(optimismSepolia),
     },
     solidity: {
-        version: "0.8.20",
+        version: "0.8.23",
         settings: {
             optimizer: {
                 enabled: true,

--- a/onchain/rollups/test/foundry/consensus/authority/Authority.t.sol
+++ b/onchain/rollups/test/foundry/consensus/authority/Authority.t.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
 /// @title Authority Test
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {Vm} from "forge-std/Vm.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
@@ -17,29 +17,11 @@ import {TestBase} from "../../util/TestBase.sol";
 contract AuthorityTest is TestBase {
     using LibInputRange for InputRange;
 
-    event OwnershipTransferred(
-        address indexed previousOwner,
-        address indexed newOwner
-    );
-
-    event ClaimSubmission(
-        address indexed submitter,
-        address indexed app,
-        InputRange inputRange,
-        bytes32 epochHash
-    );
-
-    event ClaimAcceptance(
-        address indexed app,
-        InputRange inputRange,
-        bytes32 epochHash
-    );
-
     function testConstructor(address owner) public {
         vm.assume(owner != address(0));
 
         vm.expectEmit(true, true, false, false);
-        emit OwnershipTransferred(address(0), owner);
+        emit Ownable.OwnershipTransferred(address(0), owner);
 
         vm.recordLogs();
 
@@ -123,9 +105,9 @@ contract AuthorityTest is TestBase {
         bytes32 epochHash
     ) internal {
         vm.expectEmit(true, true, false, true, address(authority));
-        emit ClaimSubmission(owner, app, inputRange, epochHash);
+        emit IConsensus.ClaimSubmission(owner, app, inputRange, epochHash);
 
         vm.expectEmit(true, false, false, true, address(authority));
-        emit ClaimAcceptance(app, inputRange, epochHash);
+        emit IConsensus.ClaimAcceptance(app, inputRange, epochHash);
     }
 }

--- a/onchain/rollups/test/foundry/consensus/authority/AuthorityFactory.t.sol
+++ b/onchain/rollups/test/foundry/consensus/authority/AuthorityFactory.t.sol
@@ -2,17 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
 /// @title Authority Factory Test
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {Test} from "forge-std/Test.sol";
-import {AuthorityFactory} from "contracts/consensus/authority/AuthorityFactory.sol";
+import {AuthorityFactory, IAuthorityFactory} from "contracts/consensus/authority/AuthorityFactory.sol";
 import {Authority} from "contracts/consensus/authority/Authority.sol";
 import {Vm} from "forge-std/Vm.sol";
 
 contract AuthorityFactoryTest is Test {
     AuthorityFactory factory;
-
-    event AuthorityCreated(address authorityOwner, Authority authority);
 
     struct AuthorityCreatedEventData {
         address authorityOwner;
@@ -46,7 +44,7 @@ contract AuthorityFactoryTest is Test {
 
             if (
                 entry.emitter == address(factory) &&
-                entry.topics[0] == AuthorityCreated.selector
+                entry.topics[0] == IAuthorityFactory.AuthorityCreated.selector
             ) {
                 ++numOfAuthorityCreated;
 

--- a/onchain/rollups/test/foundry/dapp/Application.t.sol
+++ b/onchain/rollups/test/foundry/dapp/Application.t.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
 /// @title Application Test
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {TestBase} from "../util/TestBase.sol";
 
@@ -95,13 +95,6 @@ contract ApplicationTest is TestBase {
     uint256 immutable transferAmount;
     IInputRelay[] inputRelays;
 
-    event VoucherExecuted(uint256 inputIndex, uint256 outputIndexWithinInput);
-    event OwnershipTransferred(
-        address indexed previousOwner,
-        address indexed newOwner
-    );
-    event NewConsensus(IConsensus newConsensus);
-
     constructor() {
         appOwner = LibBytes.hashToAddress("appOwner");
         initialSupply = LibBytes.hashToUint256("initialSupply");
@@ -176,7 +169,7 @@ contract ApplicationTest is TestBase {
         vm.assume(_owner != address(0));
 
         vm.expectEmit(true, true, false, false);
-        emit OwnershipTransferred(address(0), _owner);
+        emit Ownable.OwnershipTransferred(address(0), _owner);
 
         app = new Application(
             consensus,
@@ -241,7 +234,7 @@ contract ApplicationTest is TestBase {
 
         // expect event
         vm.expectEmit(false, false, false, true, address(app));
-        emit VoucherExecuted(
+        emit IApplication.VoucherExecuted(
             _calculateInputIndex(proof),
             proof.validity.outputIndexWithinInput
         );
@@ -412,7 +405,7 @@ contract ApplicationTest is TestBase {
 
         // expect event
         vm.expectEmit(false, false, false, true, address(app));
-        emit VoucherExecuted(
+        emit IApplication.VoucherExecuted(
             _calculateInputIndex(proof),
             proof.validity.outputIndexWithinInput
         );
@@ -529,7 +522,7 @@ contract ApplicationTest is TestBase {
 
         // expect event
         vm.expectEmit(false, false, false, true, address(app));
-        emit VoucherExecuted(
+        emit IApplication.VoucherExecuted(
             _calculateInputIndex(proof),
             proof.validity.outputIndexWithinInput
         );
@@ -583,7 +576,7 @@ contract ApplicationTest is TestBase {
         // now impersonate owner
         vm.prank(_owner);
         vm.expectEmit(false, false, false, true, address(app));
-        emit NewConsensus(newConsensus);
+        emit IApplication.NewConsensus(newConsensus);
         app.migrateToConsensus(newConsensus);
         assertEq(address(app.getConsensus()), address(newConsensus));
 

--- a/onchain/rollups/test/foundry/dapp/ApplicationFactory.t.sol
+++ b/onchain/rollups/test/foundry/dapp/ApplicationFactory.t.sol
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
 /// @title Application Factory Test
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {TestBase} from "../util/TestBase.sol";
 import {SimpleConsensus} from "../util/SimpleConsensus.sol";
-import {ApplicationFactory} from "contracts/dapp/ApplicationFactory.sol";
+import {ApplicationFactory, IApplicationFactory} from "contracts/dapp/ApplicationFactory.sol";
 import {Application} from "contracts/dapp/Application.sol";
 import {IConsensus} from "contracts/consensus/IConsensus.sol";
 import {IInputBox} from "contracts/inputs/IInputBox.sol";
@@ -21,15 +21,6 @@ contract ApplicationFactoryTest is TestBase {
         factory = new ApplicationFactory();
         consensus = new SimpleConsensus();
     }
-
-    event ApplicationCreated(
-        IConsensus indexed consensus,
-        IInputBox inputBox,
-        IInputRelay[] inputRelays,
-        address appOwner,
-        bytes32 templateHash,
-        Application app
-    );
 
     function testNewApplication(
         IInputBox _inputBox,
@@ -187,7 +178,8 @@ contract ApplicationFactoryTest is TestBase {
 
             if (
                 entry.emitter == address(factory) &&
-                entry.topics[0] == ApplicationCreated.selector
+                entry.topics[0] ==
+                IApplicationFactory.ApplicationCreated.selector
             ) {
                 ++numOfApplicationsCreated;
 

--- a/onchain/rollups/test/foundry/inputs/InputBox.t.sol
+++ b/onchain/rollups/test/foundry/inputs/InputBox.t.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
 /// @title Input Box Test
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {Test} from "forge-std/Test.sol";
 import {InputBox} from "contracts/inputs/InputBox.sol";
@@ -137,13 +137,6 @@ contract InputBoxTest is Test {
     InputBox inputBox;
     InputBoxHandler handler;
 
-    event InputAdded(
-        address indexed app,
-        uint256 indexed inputIndex,
-        address sender,
-        bytes input
-    );
-
     function setUp() public {
         inputBox = new InputBox();
         handler = new InputBoxHandler(inputBox);
@@ -188,7 +181,7 @@ contract InputBoxTest is Test {
             vm.expectEmit(true, true, false, true, address(inputBox));
 
             // The event we expect
-            emit InputAdded(_app, i, address(this), _inputs[i]);
+            emit IInputBox.InputAdded(_app, i, address(this), _inputs[i]);
 
             returnedValues[i] = inputBox.addInput(_app, _inputs[i]);
 

--- a/onchain/rollups/test/foundry/portals/ERC1155BatchPortal.t.sol
+++ b/onchain/rollups/test/foundry/portals/ERC1155BatchPortal.t.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/onchain/rollups/test/foundry/portals/ERC1155SinglePortal.t.sol
+++ b/onchain/rollups/test/foundry/portals/ERC1155SinglePortal.t.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/onchain/rollups/test/foundry/portals/ERC20Portal.t.sol
+++ b/onchain/rollups/test/foundry/portals/ERC20Portal.t.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/onchain/rollups/test/foundry/portals/ERC721Portal.t.sol
+++ b/onchain/rollups/test/foundry/portals/ERC721Portal.t.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/onchain/rollups/test/foundry/portals/EtherPortal.t.sol
+++ b/onchain/rollups/test/foundry/portals/EtherPortal.t.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/onchain/rollups/test/foundry/relays/ApplicationAddressRelay.t.sol
+++ b/onchain/rollups/test/foundry/relays/ApplicationAddressRelay.t.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
 /// @title Application Address Relay Test
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {Test} from "forge-std/Test.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
@@ -16,13 +16,6 @@ import {IInputRelay} from "contracts/inputs/IInputRelay.sol";
 contract ApplicationAddressRelayTest is Test {
     IInputBox inputBox;
     IApplicationAddressRelay relay;
-
-    event InputAdded(
-        address indexed app,
-        uint256 indexed inputIndex,
-        address sender,
-        bytes input
-    );
 
     function setUp() public {
         inputBox = new InputBox();
@@ -59,7 +52,7 @@ contract ApplicationAddressRelayTest is Test {
 
         // Expect InputAdded to be emitted with the right arguments
         vm.expectEmit(true, true, false, true, address(inputBox));
-        emit InputAdded(_app, 0, address(relay), input);
+        emit IInputBox.InputAdded(_app, 0, address(relay), input);
 
         // Relay the application's address
         relay.relayApplicationAddress(_app);

--- a/onchain/rollups/test/foundry/util/LibBytes.sol
+++ b/onchain/rollups/test/foundry/util/LibBytes.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 library LibBytes {
     /// @notice Generate an address from a byte array.

--- a/onchain/rollups/test/foundry/util/LibServerManager.sol
+++ b/onchain/rollups/test/foundry/util/LibServerManager.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {Vm} from "forge-std/Vm.sol";
 import {InputRange} from "contracts/common/InputRange.sol";

--- a/onchain/rollups/test/foundry/util/SimpleConsensus.sol
+++ b/onchain/rollups/test/foundry/util/SimpleConsensus.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
 /// @title A Simple Consensus Contract
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {AbstractConsensus} from "contracts/consensus/AbstractConsensus.sol";
 import {InputRange} from "contracts/common/InputRange.sol";

--- a/onchain/rollups/test/foundry/util/SimpleERC20.sol
+++ b/onchain/rollups/test/foundry/util/SimpleERC20.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
 /// @title A Simple ERC-20 Contract
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/onchain/rollups/test/foundry/util/SimpleERC721.sol
+++ b/onchain/rollups/test/foundry/util/SimpleERC721.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
 /// @title A Simple ERC-721 Contract
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/onchain/rollups/test/foundry/util/TestBase.sol
+++ b/onchain/rollups/test/foundry/util/TestBase.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
 /// @title Test base contract
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.22;
 
 import {Test} from "forge-std/Test.sol";
 


### PR DESCRIPTION
- bump solc
- allow foreign access to events in test contracts
- upgrade pragma for test contracts to 0.8.22 (reasoning is [here](https://github.com/cartesi/rollups-contracts/issues/173#issuecomment-1864447226))