### PR TITLE
comply with solidity style guide

### DIFF
--- a/onchain/rollups/.changeset/pink-penguins-kiss.md
+++ b/onchain/rollups/.changeset/pink-penguins-kiss.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": major
+---
+
+Comply with Solidity style guide.

--- a/onchain/rollups/contracts/consensus/authority/AuthorityFactory.sol
+++ b/onchain/rollups/contracts/consensus/authority/AuthorityFactory.sol
@@ -12,37 +12,37 @@ import {Authority} from "./Authority.sol";
 /// @notice Allows anyone to reliably deploy a new `Authority` contract.
 contract AuthorityFactory is IAuthorityFactory {
     function newAuthority(
-        address _authorityOwner
+        address authorityOwner
     ) external override returns (Authority) {
-        Authority authority = new Authority(_authorityOwner);
+        Authority authority = new Authority(authorityOwner);
 
-        emit AuthorityCreated(_authorityOwner, authority);
+        emit AuthorityCreated(authorityOwner, authority);
 
         return authority;
     }
 
     function newAuthority(
-        address _authorityOwner,
-        bytes32 _salt
+        address authorityOwner,
+        bytes32 salt
     ) external override returns (Authority) {
-        Authority authority = new Authority{salt: _salt}(_authorityOwner);
+        Authority authority = new Authority{salt: salt}(authorityOwner);
 
-        emit AuthorityCreated(_authorityOwner, authority);
+        emit AuthorityCreated(authorityOwner, authority);
 
         return authority;
     }
 
     function calculateAuthorityAddress(
-        address _authorityOwner,
-        bytes32 _salt
+        address authorityOwner,
+        bytes32 salt
     ) external view override returns (address) {
         return
             Create2.computeAddress(
-                _salt,
+                salt,
                 keccak256(
                     abi.encodePacked(
                         type(Authority).creationCode,
-                        abi.encode(_authorityOwner)
+                        abi.encode(authorityOwner)
                     )
                 )
             );

--- a/onchain/rollups/contracts/consensus/authority/IAuthorityFactory.sol
+++ b/onchain/rollups/contracts/consensus/authority/IAuthorityFactory.sol
@@ -18,29 +18,29 @@ interface IAuthorityFactory {
     // Permissionless functions
 
     /// @notice Deploy a new authority.
-    /// @param _authorityOwner The initial authority owner
+    /// @param authorityOwner The initial authority owner
     /// @return The authority
     /// @dev On success, MUST emit an `AuthorityCreated` event.
-    function newAuthority(address _authorityOwner) external returns (Authority);
+    function newAuthority(address authorityOwner) external returns (Authority);
 
     /// @notice Deploy a new authority deterministically.
-    /// @param _authorityOwner The initial authority owner
-    /// @param _salt The salt used to deterministically generate the authority address
+    /// @param authorityOwner The initial authority owner
+    /// @param salt The salt used to deterministically generate the authority address
     /// @return The authority
     /// @dev On success, MUST emit an `AuthorityCreated` event.
     function newAuthority(
-        address _authorityOwner,
-        bytes32 _salt
+        address authorityOwner,
+        bytes32 salt
     ) external returns (Authority);
 
     /// @notice Calculate the address of an authority to be deployed deterministically.
-    /// @param _authorityOwner The initial authority owner
-    /// @param _salt The salt used to deterministically generate the authority address
+    /// @param authorityOwner The initial authority owner
+    /// @param salt The salt used to deterministically generate the authority address
     /// @return The deterministic authority address
-    /// @dev Beware that only the `newAuthority` function with the `_salt` parameter
+    /// @dev Beware that only the `newAuthority` function with the `salt` parameter
     ///      is able to deterministically deploy an authority.
     function calculateAuthorityAddress(
-        address _authorityOwner,
-        bytes32 _salt
+        address authorityOwner,
+        bytes32 salt
     ) external view returns (address);
 }

--- a/onchain/rollups/contracts/dapp/ApplicationFactory.sol
+++ b/onchain/rollups/contracts/dapp/ApplicationFactory.sol
@@ -15,26 +15,26 @@ import {Application} from "./Application.sol";
 /// @notice Allows anyone to reliably deploy a new `Application` contract.
 contract ApplicationFactory is IApplicationFactory {
     function newApplication(
-        IConsensus _consensus,
-        IInputBox _inputBox,
-        IInputRelay[] memory _inputRelays,
-        address _appOwner,
-        bytes32 _templateHash
+        IConsensus consensus,
+        IInputBox inputBox,
+        IInputRelay[] memory inputRelays,
+        address appOwner,
+        bytes32 templateHash
     ) external override returns (Application) {
         Application app = new Application(
-            _consensus,
-            _inputBox,
-            _inputRelays,
-            _appOwner,
-            _templateHash
+            consensus,
+            inputBox,
+            inputRelays,
+            appOwner,
+            templateHash
         );
 
         emit ApplicationCreated(
-            _consensus,
-            _inputBox,
-            _inputRelays,
-            _appOwner,
-            _templateHash,
+            consensus,
+            inputBox,
+            inputRelays,
+            appOwner,
+            templateHash,
             app
         );
 
@@ -42,27 +42,27 @@ contract ApplicationFactory is IApplicationFactory {
     }
 
     function newApplication(
-        IConsensus _consensus,
-        IInputBox _inputBox,
-        IInputRelay[] memory _inputRelays,
-        address _appOwner,
-        bytes32 _templateHash,
-        bytes32 _salt
+        IConsensus consensus,
+        IInputBox inputBox,
+        IInputRelay[] memory inputRelays,
+        address appOwner,
+        bytes32 templateHash,
+        bytes32 salt
     ) external override returns (Application) {
-        Application app = new Application{salt: _salt}(
-            _consensus,
-            _inputBox,
-            _inputRelays,
-            _appOwner,
-            _templateHash
+        Application app = new Application{salt: salt}(
+            consensus,
+            inputBox,
+            inputRelays,
+            appOwner,
+            templateHash
         );
 
         emit ApplicationCreated(
-            _consensus,
-            _inputBox,
-            _inputRelays,
-            _appOwner,
-            _templateHash,
+            consensus,
+            inputBox,
+            inputRelays,
+            appOwner,
+            templateHash,
             app
         );
 
@@ -70,25 +70,25 @@ contract ApplicationFactory is IApplicationFactory {
     }
 
     function calculateApplicationAddress(
-        IConsensus _consensus,
-        IInputBox _inputBox,
-        IInputRelay[] memory _inputRelays,
-        address _appOwner,
-        bytes32 _templateHash,
-        bytes32 _salt
+        IConsensus consensus,
+        IInputBox inputBox,
+        IInputRelay[] memory inputRelays,
+        address appOwner,
+        bytes32 templateHash,
+        bytes32 salt
     ) external view override returns (address) {
         return
             Create2.computeAddress(
-                _salt,
+                salt,
                 keccak256(
                     abi.encodePacked(
                         type(Application).creationCode,
                         abi.encode(
-                            _consensus,
-                            _inputBox,
-                            _inputRelays,
-                            _appOwner,
-                            _templateHash
+                            consensus,
+                            inputBox,
+                            inputRelays,
+                            appOwner,
+                            templateHash
                         )
                     )
                 )

--- a/onchain/rollups/contracts/dapp/IApplication.sol
+++ b/onchain/rollups/contracts/dapp/IApplication.sol
@@ -15,14 +15,6 @@ import {InputRange} from "../common/InputRange.sol";
 
 /// @title Application interface
 interface IApplication is IERC721Receiver, IERC1155Receiver {
-    // Errors
-
-    /// @notice Could not validate an output because
-    /// the input that generated it is outside the given input range.
-    /// @param inputIndex The input index
-    /// @param inputRange The input range
-    error InputIndexOutOfRange(uint256 inputIndex, InputRange inputRange);
-
     // Events
 
     /// @notice The application has migrated to another consensus contract.
@@ -35,12 +27,20 @@ interface IApplication is IERC721Receiver, IERC1155Receiver {
     /// @param outputIndexWithinInput The index of the voucher amongst all outputs emitted by the input
     event VoucherExecuted(uint256 inputIndex, uint256 outputIndexWithinInput);
 
+    // Errors
+
+    /// @notice Could not validate an output because
+    /// the input that generated it is outside the given input range.
+    /// @param inputIndex The input index
+    /// @param inputRange The input range
+    error InputIndexOutOfRange(uint256 inputIndex, InputRange inputRange);
+
     // Permissioned functions
 
     /// @notice Migrate the application to a new consensus.
-    /// @param _newConsensus The new consensus
+    /// @param newConsensus The new consensus
     /// @dev Can only be called by the application owner.
-    function migrateToConsensus(IConsensus _newConsensus) external;
+    function migrateToConsensus(IConsensus newConsensus) external;
 
     // Permissionless functions
 
@@ -48,34 +48,34 @@ interface IApplication is IERC721Receiver, IERC1155Receiver {
     /// Reverts if the proof is invalid.
     /// Reverts if the voucher was already successfully executed.
     /// Propagates any error raised by the low-level call.
-    /// @param _destination The address that will receive the payload through a message call
-    /// @param _payload The payload, which—in the case of Solidity contracts—encodes a function call
-    /// @param _proof The proof used to validate the voucher against
+    /// @param destination The address that will receive the payload through a message call
+    /// @param payload The payload, which—in the case of Solidity contracts—encodes a function call
+    /// @param proof The proof used to validate the voucher against
     ///               a claim submitted by the current consensus contract
     /// @dev On a successful execution, emits a `VoucherExecuted` event.
     function executeVoucher(
-        address _destination,
-        bytes calldata _payload,
-        Proof calldata _proof
+        address destination,
+        bytes calldata payload,
+        Proof calldata proof
     ) external;
 
     /// @notice Check whether a voucher has been executed.
-    /// @param _inputIndex The index of the input in the input box
-    /// @param _outputIndexWithinInput The index of output emitted by the input
+    /// @param inputIndex The index of the input in the input box
+    /// @param outputIndexWithinInput The index of output emitted by the input
     /// @return Whether the voucher has been executed before
     function wasVoucherExecuted(
-        uint256 _inputIndex,
-        uint256 _outputIndexWithinInput
+        uint256 inputIndex,
+        uint256 outputIndexWithinInput
     ) external view returns (bool);
 
     /// @notice Validate a notice.
     /// Reverts if the proof is invalid.
-    /// @param _notice The notice
-    /// @param _proof The proof used to validate the notice against
+    /// @param notice The notice
+    /// @param proof The proof used to validate the notice against
     ///               a claim submitted by the current consensus contract
     function validateNotice(
-        bytes calldata _notice,
-        Proof calldata _proof
+        bytes calldata notice,
+        Proof calldata proof
     ) external view;
 
     /// @notice Get the application's template hash.

--- a/onchain/rollups/contracts/dapp/IApplicationFactory.sol
+++ b/onchain/rollups/contracts/dapp/IApplicationFactory.sol
@@ -32,55 +32,55 @@ interface IApplicationFactory {
     // Permissionless functions
 
     /// @notice Deploy a new application.
-    /// @param _consensus The initial consensus contract
-    /// @param _inputBox The input box contract
-    /// @param _inputRelays The input relays
-    /// @param _appOwner The initial application owner
-    /// @param _templateHash The initial machine state hash
+    /// @param consensus The initial consensus contract
+    /// @param inputBox The input box contract
+    /// @param inputRelays The input relays
+    /// @param appOwner The initial application owner
+    /// @param templateHash The initial machine state hash
     /// @return The application
     /// @dev On success, MUST emit an `ApplicationCreated` event.
     function newApplication(
-        IConsensus _consensus,
-        IInputBox _inputBox,
-        IInputRelay[] calldata _inputRelays,
-        address _appOwner,
-        bytes32 _templateHash
+        IConsensus consensus,
+        IInputBox inputBox,
+        IInputRelay[] calldata inputRelays,
+        address appOwner,
+        bytes32 templateHash
     ) external returns (Application);
 
     /// @notice Deploy a new application deterministically.
-    /// @param _consensus The initial consensus contract
-    /// @param _inputBox The input box contract
-    /// @param _inputRelays The input relays
-    /// @param _appOwner The initial application owner
-    /// @param _templateHash The initial machine state hash
-    /// @param _salt The salt used to deterministically generate the application address
+    /// @param consensus The initial consensus contract
+    /// @param inputBox The input box contract
+    /// @param inputRelays The input relays
+    /// @param appOwner The initial application owner
+    /// @param templateHash The initial machine state hash
+    /// @param salt The salt used to deterministically generate the application address
     /// @return The application
     /// @dev On success, MUST emit an `ApplicationCreated` event.
     function newApplication(
-        IConsensus _consensus,
-        IInputBox _inputBox,
-        IInputRelay[] calldata _inputRelays,
-        address _appOwner,
-        bytes32 _templateHash,
-        bytes32 _salt
+        IConsensus consensus,
+        IInputBox inputBox,
+        IInputRelay[] calldata inputRelays,
+        address appOwner,
+        bytes32 templateHash,
+        bytes32 salt
     ) external returns (Application);
 
     /// @notice Calculate the address of an application to be deployed deterministically.
-    /// @param _consensus The initial consensus contract
-    /// @param _inputBox The input box contract
-    /// @param _inputRelays The input relays
-    /// @param _appOwner The initial application owner
-    /// @param _templateHash The initial machine state hash
-    /// @param _salt The salt used to deterministically generate the application address
+    /// @param consensus The initial consensus contract
+    /// @param inputBox The input box contract
+    /// @param inputRelays The input relays
+    /// @param appOwner The initial application owner
+    /// @param templateHash The initial machine state hash
+    /// @param salt The salt used to deterministically generate the application address
     /// @return The deterministic application address
-    /// @dev Beware that only the `newApplication` function with the `_salt` parameter
+    /// @dev Beware that only the `newApplication` function with the `salt` parameter
     ///      is able to deterministically deploy an application.
     function calculateApplicationAddress(
-        IConsensus _consensus,
-        IInputBox _inputBox,
-        IInputRelay[] calldata _inputRelays,
-        address _appOwner,
-        bytes32 _templateHash,
-        bytes32 _salt
+        IConsensus consensus,
+        IInputBox inputBox,
+        IInputRelay[] calldata inputRelays,
+        address appOwner,
+        bytes32 templateHash,
+        bytes32 salt
     ) external view returns (address);
 }

--- a/onchain/rollups/contracts/inputs/IInputBox.sol
+++ b/onchain/rollups/contracts/inputs/IInputBox.sol
@@ -19,29 +19,29 @@ interface IInputBox {
     );
 
     /// @notice Add an input to an application's input box.
-    /// @param _app The address of the application
-    /// @param _input The contents of the input
+    /// @param app The address of the application
+    /// @param input The contents of the input
     /// @return The hash of the input plus some extra metadata
     /// @dev MUST fire an `InputAdded` event accordingly.
     ///      Input larger than machine limit will raise `InputSizeExceedsLimit` error.
     function addInput(
-        address _app,
-        bytes calldata _input
+        address app,
+        bytes calldata input
     ) external returns (bytes32);
 
     /// @notice Get the number of inputs in an application's input box.
-    /// @param _app The address of the application
+    /// @param app The address of the application
     /// @return Number of inputs in the application's input box
-    function getNumberOfInputs(address _app) external view returns (uint256);
+    function getNumberOfInputs(address app) external view returns (uint256);
 
     /// @notice Get the hash of an input in an application's input box.
-    /// @param _app The address of the application
-    /// @param _index The index of the input in the application's input box
+    /// @param app The address of the application
+    /// @param index The index of the input in the application's input box
     /// @return The hash of the input at the provided index in the application's input box
-    /// @dev `_index` MUST be in the interval `[0,n)` where `n` is the number of
+    /// @dev `index` MUST be in the interval `[0,n)` where `n` is the number of
     ///      inputs in the application's input box. See the `getNumberOfInputs` function.
     function getInputHash(
-        address _app,
-        uint256 _index
+        address app,
+        uint256 index
     ) external view returns (bytes32);
 }

--- a/onchain/rollups/contracts/inputs/InputBox.sol
+++ b/onchain/rollups/contracts/inputs/InputBox.sol
@@ -25,20 +25,20 @@ import {LibInput} from "../library/LibInput.sol";
 contract InputBox is IInputBox {
     /// @notice Mapping from application address to list of input hashes.
     /// @dev See the `getNumberOfInputs`, `getInputHash` and `addInput` functions.
-    mapping(address => bytes32[]) internal inputBoxes;
+    mapping(address => bytes32[]) internal _inputBoxes;
 
     function addInput(
-        address _app,
-        bytes calldata _input
+        address app,
+        bytes calldata input
     ) external override returns (bytes32) {
-        bytes32[] storage inputBox = inputBoxes[_app];
+        bytes32[] storage inputBox = _inputBoxes[app];
         uint256 inputIndex = inputBox.length;
 
         bytes32 inputHash = LibInput.computeInputHash(
             msg.sender,
             block.number,
             block.timestamp,
-            _input,
+            input,
             inputIndex
         );
 
@@ -46,21 +46,21 @@ contract InputBox is IInputBox {
         inputBox.push(inputHash);
 
         // block.number and timestamp can be retrieved by the event metadata itself
-        emit InputAdded(_app, inputIndex, msg.sender, _input);
+        emit InputAdded(app, inputIndex, msg.sender, input);
 
         return inputHash;
     }
 
     function getNumberOfInputs(
-        address _app
+        address app
     ) external view override returns (uint256) {
-        return inputBoxes[_app].length;
+        return _inputBoxes[app].length;
     }
 
     function getInputHash(
-        address _app,
-        uint256 _index
+        address app,
+        uint256 index
     ) external view override returns (bytes32) {
-        return inputBoxes[_app][_index];
+        return _inputBoxes[app][index];
     }
 }

--- a/onchain/rollups/contracts/inputs/InputRelay.sol
+++ b/onchain/rollups/contracts/inputs/InputRelay.sol
@@ -11,12 +11,16 @@ import {ERC165, IERC165} from "@openzeppelin/contracts/utils/introspection/ERC16
 /// @notice This contract serves as a base for all the other input relays.
 contract InputRelay is IInputRelay, ERC165 {
     /// @notice The input box used by the input relay.
-    IInputBox internal immutable inputBox;
+    IInputBox internal immutable _inputBox;
 
     /// @notice Constructs the input relay.
-    /// @param _inputBox The input box used by the input relay
-    constructor(IInputBox _inputBox) {
-        inputBox = _inputBox;
+    /// @param inputBox The input box used by the input relay
+    constructor(IInputBox inputBox) {
+        _inputBox = inputBox;
+    }
+
+    function getInputBox() external view override returns (IInputBox) {
+        return _inputBox;
     }
 
     function supportsInterface(
@@ -25,9 +29,5 @@ contract InputRelay is IInputRelay, ERC165 {
         return
             interfaceId == type(IInputRelay).interfaceId ||
             super.supportsInterface(interfaceId);
-    }
-
-    function getInputBox() external view override returns (IInputBox) {
-        return inputBox;
     }
 }

--- a/onchain/rollups/contracts/portals/ERC1155SinglePortal.sol
+++ b/onchain/rollups/contracts/portals/ERC1155SinglePortal.sol
@@ -17,8 +17,30 @@ import {InputEncoding} from "../common/InputEncoding.sol";
 /// ERC-1155 tokens to an application while informing the off-chain machine.
 contract ERC1155SinglePortal is IERC1155SinglePortal, InputRelay {
     /// @notice Constructs the portal.
-    /// @param _inputBox The input box used by the portal
-    constructor(IInputBox _inputBox) InputRelay(_inputBox) {}
+    /// @param inputBox The input box used by the portal
+    constructor(IInputBox inputBox) InputRelay(inputBox) {}
+
+    function depositSingleERC1155Token(
+        IERC1155 token,
+        address app,
+        uint256 tokenId,
+        uint256 value,
+        bytes calldata baseLayerData,
+        bytes calldata execLayerData
+    ) external override {
+        token.safeTransferFrom(msg.sender, app, tokenId, value, baseLayerData);
+
+        bytes memory input = InputEncoding.encodeSingleERC1155Deposit(
+            token,
+            msg.sender,
+            tokenId,
+            value,
+            baseLayerData,
+            execLayerData
+        );
+
+        _inputBox.addInput(app, input);
+    }
 
     function supportsInterface(
         bytes4 interfaceId
@@ -26,33 +48,5 @@ contract ERC1155SinglePortal is IERC1155SinglePortal, InputRelay {
         return
             interfaceId == type(IERC1155SinglePortal).interfaceId ||
             super.supportsInterface(interfaceId);
-    }
-
-    function depositSingleERC1155Token(
-        IERC1155 _token,
-        address _app,
-        uint256 _tokenId,
-        uint256 _value,
-        bytes calldata _baseLayerData,
-        bytes calldata _execLayerData
-    ) external override {
-        _token.safeTransferFrom(
-            msg.sender,
-            _app,
-            _tokenId,
-            _value,
-            _baseLayerData
-        );
-
-        bytes memory input = InputEncoding.encodeSingleERC1155Deposit(
-            _token,
-            msg.sender,
-            _tokenId,
-            _value,
-            _baseLayerData,
-            _execLayerData
-        );
-
-        inputBox.addInput(_app, input);
     }
 }

--- a/onchain/rollups/contracts/portals/ERC20Portal.sol
+++ b/onchain/rollups/contracts/portals/ERC20Portal.sol
@@ -20,8 +20,26 @@ contract ERC20Portal is IERC20Portal, InputRelay {
     using SafeERC20 for IERC20;
 
     /// @notice Constructs the portal.
-    /// @param _inputBox The input box used by the portal
-    constructor(IInputBox _inputBox) InputRelay(_inputBox) {}
+    /// @param inputBox The input box used by the portal
+    constructor(IInputBox inputBox) InputRelay(inputBox) {}
+
+    function depositERC20Tokens(
+        IERC20 token,
+        address app,
+        uint256 amount,
+        bytes calldata execLayerData
+    ) external override {
+        token.safeTransferFrom(msg.sender, app, amount);
+
+        bytes memory input = InputEncoding.encodeERC20Deposit(
+            token,
+            msg.sender,
+            amount,
+            execLayerData
+        );
+
+        _inputBox.addInput(app, input);
+    }
 
     function supportsInterface(
         bytes4 interfaceId
@@ -29,23 +47,5 @@ contract ERC20Portal is IERC20Portal, InputRelay {
         return
             interfaceId == type(IERC20Portal).interfaceId ||
             super.supportsInterface(interfaceId);
-    }
-
-    function depositERC20Tokens(
-        IERC20 _token,
-        address _app,
-        uint256 _amount,
-        bytes calldata _execLayerData
-    ) external override {
-        _token.safeTransferFrom(msg.sender, _app, _amount);
-
-        bytes memory input = InputEncoding.encodeERC20Deposit(
-            _token,
-            msg.sender,
-            _amount,
-            _execLayerData
-        );
-
-        inputBox.addInput(_app, input);
     }
 }

--- a/onchain/rollups/contracts/portals/ERC721Portal.sol
+++ b/onchain/rollups/contracts/portals/ERC721Portal.sol
@@ -17,8 +17,28 @@ import {InputEncoding} from "../common/InputEncoding.sol";
 /// ERC-721 tokens to an application while informing the off-chain machine.
 contract ERC721Portal is IERC721Portal, InputRelay {
     /// @notice Constructs the portal.
-    /// @param _inputBox The input box used by the portal
-    constructor(IInputBox _inputBox) InputRelay(_inputBox) {}
+    /// @param inputBox The input box used by the portal
+    constructor(IInputBox inputBox) InputRelay(inputBox) {}
+
+    function depositERC721Token(
+        IERC721 token,
+        address app,
+        uint256 tokenId,
+        bytes calldata baseLayerData,
+        bytes calldata execLayerData
+    ) external override {
+        token.safeTransferFrom(msg.sender, app, tokenId, baseLayerData);
+
+        bytes memory input = InputEncoding.encodeERC721Deposit(
+            token,
+            msg.sender,
+            tokenId,
+            baseLayerData,
+            execLayerData
+        );
+
+        _inputBox.addInput(app, input);
+    }
 
     function supportsInterface(
         bytes4 interfaceId
@@ -26,25 +46,5 @@ contract ERC721Portal is IERC721Portal, InputRelay {
         return
             interfaceId == type(IERC721Portal).interfaceId ||
             super.supportsInterface(interfaceId);
-    }
-
-    function depositERC721Token(
-        IERC721 _token,
-        address _app,
-        uint256 _tokenId,
-        bytes calldata _baseLayerData,
-        bytes calldata _execLayerData
-    ) external override {
-        _token.safeTransferFrom(msg.sender, _app, _tokenId, _baseLayerData);
-
-        bytes memory input = InputEncoding.encodeERC721Deposit(
-            _token,
-            msg.sender,
-            _tokenId,
-            _baseLayerData,
-            _execLayerData
-        );
-
-        inputBox.addInput(_app, input);
     }
 }

--- a/onchain/rollups/contracts/portals/EtherPortal.sol
+++ b/onchain/rollups/contracts/portals/EtherPortal.sol
@@ -19,8 +19,23 @@ contract EtherPortal is IEtherPortal, InputRelay {
     using Address for address payable;
 
     /// @notice Constructs the portal.
-    /// @param _inputBox The input box used by the portal
-    constructor(IInputBox _inputBox) InputRelay(_inputBox) {}
+    /// @param inputBox The input box used by the portal
+    constructor(IInputBox inputBox) InputRelay(inputBox) {}
+
+    function depositEther(
+        address payable app,
+        bytes calldata execLayerData
+    ) external payable override {
+        app.sendValue(msg.value);
+
+        bytes memory input = InputEncoding.encodeEtherDeposit(
+            msg.sender,
+            msg.value,
+            execLayerData
+        );
+
+        _inputBox.addInput(app, input);
+    }
 
     function supportsInterface(
         bytes4 interfaceId
@@ -28,20 +43,5 @@ contract EtherPortal is IEtherPortal, InputRelay {
         return
             interfaceId == type(IEtherPortal).interfaceId ||
             super.supportsInterface(interfaceId);
-    }
-
-    function depositEther(
-        address payable _app,
-        bytes calldata _execLayerData
-    ) external payable override {
-        _app.sendValue(msg.value);
-
-        bytes memory input = InputEncoding.encodeEtherDeposit(
-            msg.sender,
-            msg.value,
-            _execLayerData
-        );
-
-        inputBox.addInput(_app, input);
     }
 }

--- a/onchain/rollups/contracts/portals/IERC1155BatchPortal.sol
+++ b/onchain/rollups/contracts/portals/IERC1155BatchPortal.sol
@@ -16,20 +16,20 @@ interface IERC1155BatchPortal is IInputRelay {
     /// The caller must enable approval for the portal to manage all of their tokens
     /// beforehand, by calling the `setApprovalForAll` function in the token contract.
     ///
-    /// @param _token The ERC-1155 token contract
-    /// @param _app The address of the application
-    /// @param _tokenIds The identifiers of the tokens being transferred
-    /// @param _values Transfer amounts per token type
-    /// @param _baseLayerData Additional data to be interpreted by the base layer
-    /// @param _execLayerData Additional data to be interpreted by the execution layer
+    /// @param token The ERC-1155 token contract
+    /// @param app The address of the application
+    /// @param tokenIds The identifiers of the tokens being transferred
+    /// @param values Transfer amounts per token type
+    /// @param baseLayerData Additional data to be interpreted by the base layer
+    /// @param execLayerData Additional data to be interpreted by the execution layer
     ///
-    /// @dev Please make sure `_tokenIds` and `_values` have the same length.
+    /// @dev Please make sure `tokenIds` and `values` have the same length.
     function depositBatchERC1155Token(
-        IERC1155 _token,
-        address _app,
-        uint256[] calldata _tokenIds,
-        uint256[] calldata _values,
-        bytes calldata _baseLayerData,
-        bytes calldata _execLayerData
+        IERC1155 token,
+        address app,
+        uint256[] calldata tokenIds,
+        uint256[] calldata values,
+        bytes calldata baseLayerData,
+        bytes calldata execLayerData
     ) external;
 }

--- a/onchain/rollups/contracts/portals/IERC1155SinglePortal.sol
+++ b/onchain/rollups/contracts/portals/IERC1155SinglePortal.sol
@@ -16,18 +16,18 @@ interface IERC1155SinglePortal is IInputRelay {
     /// The caller must enable approval for the portal to manage all of their tokens
     /// beforehand, by calling the `setApprovalForAll` function in the token contract.
     ///
-    /// @param _token The ERC-1155 token contract
-    /// @param _app The address of the application
-    /// @param _tokenId The identifier of the token being transferred
-    /// @param _value Transfer amount
-    /// @param _baseLayerData Additional data to be interpreted by the base layer
-    /// @param _execLayerData Additional data to be interpreted by the execution layer
+    /// @param token The ERC-1155 token contract
+    /// @param app The address of the application
+    /// @param tokenId The identifier of the token being transferred
+    /// @param value Transfer amount
+    /// @param baseLayerData Additional data to be interpreted by the base layer
+    /// @param execLayerData Additional data to be interpreted by the execution layer
     function depositSingleERC1155Token(
-        IERC1155 _token,
-        address _app,
-        uint256 _tokenId,
-        uint256 _value,
-        bytes calldata _baseLayerData,
-        bytes calldata _execLayerData
+        IERC1155 token,
+        address app,
+        uint256 tokenId,
+        uint256 value,
+        bytes calldata baseLayerData,
+        bytes calldata execLayerData
     ) external;
 }

--- a/onchain/rollups/contracts/portals/IERC20Portal.sol
+++ b/onchain/rollups/contracts/portals/IERC20Portal.sol
@@ -13,18 +13,18 @@ interface IERC20Portal is IInputRelay {
     /// @notice Transfer ERC-20 tokens to an application and add an input to
     /// the application's input box to signal such operation.
     ///
-    /// The caller must allow the portal to withdraw at least `_amount` tokens
+    /// The caller must allow the portal to withdraw at least `amount` tokens
     /// from their account beforehand, by calling the `approve` function in the
     /// token contract.
     ///
-    /// @param _token The ERC-20 token contract
-    /// @param _app The address of the application
-    /// @param _amount The amount of tokens to be transferred
-    /// @param _execLayerData Additional data to be interpreted by the execution layer
+    /// @param token The ERC-20 token contract
+    /// @param app The address of the application
+    /// @param amount The amount of tokens to be transferred
+    /// @param execLayerData Additional data to be interpreted by the execution layer
     function depositERC20Tokens(
-        IERC20 _token,
-        address _app,
-        uint256 _amount,
-        bytes calldata _execLayerData
+        IERC20 token,
+        address app,
+        uint256 amount,
+        bytes calldata execLayerData
     ) external;
 }

--- a/onchain/rollups/contracts/portals/IERC721Portal.sol
+++ b/onchain/rollups/contracts/portals/IERC721Portal.sol
@@ -17,16 +17,16 @@ interface IERC721Portal is IInputRelay {
     /// to the portal address beforehand, by calling the `approve` function in the
     /// token contract.
     ///
-    /// @param _token The ERC-721 token contract
-    /// @param _app The address of the application
-    /// @param _tokenId The identifier of the token being transferred
-    /// @param _baseLayerData Additional data to be interpreted by the base layer
-    /// @param _execLayerData Additional data to be interpreted by the execution layer
+    /// @param token The ERC-721 token contract
+    /// @param app The address of the application
+    /// @param tokenId The identifier of the token being transferred
+    /// @param baseLayerData Additional data to be interpreted by the base layer
+    /// @param execLayerData Additional data to be interpreted by the execution layer
     function depositERC721Token(
-        IERC721 _token,
-        address _app,
-        uint256 _tokenId,
-        bytes calldata _baseLayerData,
-        bytes calldata _execLayerData
+        IERC721 token,
+        address app,
+        uint256 tokenId,
+        bytes calldata baseLayerData,
+        bytes calldata execLayerData
     ) external;
 }

--- a/onchain/rollups/contracts/portals/IEtherPortal.sol
+++ b/onchain/rollups/contracts/portals/IEtherPortal.sol
@@ -14,12 +14,12 @@ interface IEtherPortal is IInputRelay {
     ///
     /// All the value sent through this function is forwarded to the application.
     ///
-    /// @param _app The address of the application
-    /// @param _execLayerData Additional data to be interpreted by the execution layer
+    /// @param app The address of the application
+    /// @param execLayerData Additional data to be interpreted by the execution layer
     /// @dev All the value sent through this function is forwarded to the application.
     ///      If the transfer fails, `EtherTransferFailed` error is raised.
     function depositEther(
-        address payable _app,
-        bytes calldata _execLayerData
+        address payable app,
+        bytes calldata execLayerData
     ) external payable;
 }

--- a/onchain/rollups/contracts/relays/ApplicationAddressRelay.sol
+++ b/onchain/rollups/contracts/relays/ApplicationAddressRelay.sol
@@ -16,8 +16,13 @@ import {InputEncoding} from "../common/InputEncoding.sol";
 /// of the address of the application contract in a trustless and permissionless way.
 contract ApplicationAddressRelay is IApplicationAddressRelay, InputRelay {
     /// @notice Constructs the relay.
-    /// @param _inputBox The input box used by the relay
-    constructor(IInputBox _inputBox) InputRelay(_inputBox) {}
+    /// @param inputBox The input box used by the relay
+    constructor(IInputBox inputBox) InputRelay(inputBox) {}
+
+    function relayApplicationAddress(address app) external override {
+        bytes memory input = InputEncoding.encodeApplicationAddressRelay(app);
+        _inputBox.addInput(app, input);
+    }
 
     function supportsInterface(
         bytes4 interfaceId
@@ -25,10 +30,5 @@ contract ApplicationAddressRelay is IApplicationAddressRelay, InputRelay {
         return
             interfaceId == type(IApplicationAddressRelay).interfaceId ||
             super.supportsInterface(interfaceId);
-    }
-
-    function relayApplicationAddress(address _app) external override {
-        bytes memory input = InputEncoding.encodeApplicationAddressRelay(_app);
-        inputBox.addInput(_app, input);
     }
 }

--- a/onchain/rollups/contracts/relays/IApplicationAddressRelay.sol
+++ b/onchain/rollups/contracts/relays/IApplicationAddressRelay.sol
@@ -10,6 +10,6 @@ interface IApplicationAddressRelay is IInputRelay {
     // Permissionless functions
 
     /// @notice Add an input to an application's input box with its address.
-    /// @param _app The address of the application
-    function relayApplicationAddress(address _app) external;
+    /// @param app The address of the application
+    function relayApplicationAddress(address app) external;
 }

--- a/onchain/rollups/test/foundry/consensus/authority/Authority.t.sol
+++ b/onchain/rollups/test/foundry/consensus/authority/Authority.t.sol
@@ -80,7 +80,7 @@ contract AuthorityTest is TestBase {
 
         // First claim
 
-        expectClaimEvents(authority, owner, app, inputRange, epochHash1);
+        _expectClaimEvents(authority, owner, app, inputRange, epochHash1);
 
         vm.prank(owner);
         authority.submitClaim(app, inputRange, epochHash1);
@@ -89,7 +89,7 @@ contract AuthorityTest is TestBase {
 
         // Second claim
 
-        expectClaimEvents(authority, owner, app, inputRange, epochHash2);
+        _expectClaimEvents(authority, owner, app, inputRange, epochHash2);
 
         vm.prank(owner);
         authority.submitClaim(app, inputRange, epochHash2);
@@ -97,7 +97,7 @@ contract AuthorityTest is TestBase {
         assertEq(authority.getEpochHash(app, inputRange), epochHash2);
     }
 
-    function expectClaimEvents(
+    function _expectClaimEvents(
         Authority authority,
         address owner,
         address app,

--- a/onchain/rollups/test/foundry/dapp/ApplicationFactory.t.sol
+++ b/onchain/rollups/test/foundry/dapp/ApplicationFactory.t.sol
@@ -14,81 +14,81 @@ import {IInputRelay} from "contracts/inputs/IInputRelay.sol";
 import {Vm} from "forge-std/Vm.sol";
 
 contract ApplicationFactoryTest is TestBase {
-    ApplicationFactory factory;
-    IConsensus consensus;
+    ApplicationFactory _factory;
+    IConsensus _consensus;
 
     function setUp() public {
-        factory = new ApplicationFactory();
-        consensus = new SimpleConsensus();
+        _factory = new ApplicationFactory();
+        _consensus = new SimpleConsensus();
     }
 
     function testNewApplication(
-        IInputBox _inputBox,
-        IInputRelay[] calldata _inputRelays,
-        address _appOwner,
-        bytes32 _templateHash
+        IInputBox inputBox,
+        IInputRelay[] calldata inputRelays,
+        address appOwner,
+        bytes32 templateHash
     ) public {
-        vm.assume(_appOwner != address(0));
+        vm.assume(appOwner != address(0));
 
-        Application app = factory.newApplication(
-            consensus,
-            _inputBox,
-            _inputRelays,
-            _appOwner,
-            _templateHash
+        Application app = _factory.newApplication(
+            _consensus,
+            inputBox,
+            inputRelays,
+            appOwner,
+            templateHash
         );
 
-        assertEq(address(app.getConsensus()), address(consensus));
-        assertEq(address(app.getInputBox()), address(_inputBox));
+        assertEq(address(app.getConsensus()), address(_consensus));
+        assertEq(address(app.getInputBox()), address(inputBox));
         // abi.encode is used instead of a loop
-        assertEq(abi.encode(app.getInputRelays()), abi.encode(_inputRelays));
-        assertEq(app.owner(), _appOwner);
-        assertEq(app.getTemplateHash(), _templateHash);
+        assertEq(abi.encode(app.getInputRelays()), abi.encode(inputRelays));
+        assertEq(app.owner(), appOwner);
+        assertEq(app.getTemplateHash(), templateHash);
     }
 
     function testNewApplicationDeterministic(
-        IInputBox _inputBox,
-        IInputRelay[] calldata _inputRelays,
-        address _appOwner,
-        bytes32 _templateHash,
-        bytes32 _salt
+        IInputBox inputBox,
+        IInputRelay[] calldata inputRelays,
+        address appOwner,
+        bytes32 templateHash,
+        bytes32 salt
     ) public {
-        vm.assume(_appOwner != address(0));
+        vm.assume(appOwner != address(0));
 
-        address precalculatedAddress = factory.calculateApplicationAddress(
-            consensus,
-            _inputBox,
-            _inputRelays,
-            _appOwner,
-            _templateHash,
-            _salt
+        address precalculatedAddress = _factory.calculateApplicationAddress(
+            _consensus,
+            inputBox,
+            inputRelays,
+            appOwner,
+            templateHash,
+            salt
         );
 
-        Application app = factory.newApplication(
-            consensus,
-            _inputBox,
-            _inputRelays,
-            _appOwner,
-            _templateHash,
-            _salt
+        Application app = _factory.newApplication(
+            _consensus,
+            inputBox,
+            inputRelays,
+            appOwner,
+            templateHash,
+            salt
         );
 
         // Precalculated address must match actual address
         assertEq(precalculatedAddress, address(app));
 
-        assertEq(address(app.getConsensus()), address(consensus));
-        assertEq(address(app.getInputBox()), address(_inputBox));
-        assertEq(abi.encode(app.getInputRelays()), abi.encode(_inputRelays));
-        assertEq(app.owner(), _appOwner);
-        assertEq(app.getTemplateHash(), _templateHash);
+        assertEq(address(app.getConsensus()), address(_consensus));
+        assertEq(address(app.getInputBox()), address(inputBox));
+        assertEq(abi.encode(app.getInputRelays()), abi.encode(inputRelays));
+        assertEq(app.owner(), appOwner);
+        assertEq(app.getTemplateHash(), templateHash);
 
-        precalculatedAddress = factory.calculateApplicationAddress(
-            consensus,
-            _inputBox,
-            _inputRelays,
-            _appOwner,
-            _templateHash,
-            _salt
+        precalculatedAddress = _factory.calculateApplicationAddress(
+            _consensus,
+            inputBox,
+            inputRelays,
+            appOwner,
+            templateHash,
+            salt
         );
 
         // Precalculated address must STILL match actual address
@@ -96,78 +96,78 @@ contract ApplicationFactoryTest is TestBase {
 
         // Cannot deploy an application with the same salt twice
         vm.expectRevert(bytes(""));
-        factory.newApplication(
-            consensus,
-            _inputBox,
-            _inputRelays,
-            _appOwner,
-            _templateHash,
-            _salt
+        _factory.newApplication(
+            _consensus,
+            inputBox,
+            inputRelays,
+            appOwner,
+            templateHash,
+            salt
         );
     }
 
     function testApplicationCreatedEvent(
-        IInputBox _inputBox,
-        IInputRelay[] calldata _inputRelays,
-        address _appOwner,
-        bytes32 _templateHash
+        IInputBox inputBox,
+        IInputRelay[] calldata inputRelays,
+        address appOwner,
+        bytes32 templateHash
     ) public {
-        vm.assume(_appOwner != address(0));
+        vm.assume(appOwner != address(0));
 
         vm.recordLogs();
 
-        Application app = factory.newApplication(
-            consensus,
-            _inputBox,
-            _inputRelays,
-            _appOwner,
-            _templateHash
+        Application app = _factory.newApplication(
+            _consensus,
+            inputBox,
+            inputRelays,
+            appOwner,
+            templateHash
         );
 
-        testApplicationCreatedEventAux(
-            _inputBox,
-            _inputRelays,
-            _appOwner,
-            _templateHash,
+        _testApplicationCreatedEventAux(
+            inputBox,
+            inputRelays,
+            appOwner,
+            templateHash,
             app
         );
     }
 
     function testApplicationCreatedEventDeterministic(
-        IInputBox _inputBox,
-        IInputRelay[] calldata _inputRelays,
-        address _appOwner,
-        bytes32 _templateHash,
-        bytes32 _salt
+        IInputBox inputBox,
+        IInputRelay[] calldata inputRelays,
+        address appOwner,
+        bytes32 templateHash,
+        bytes32 salt
     ) public {
-        vm.assume(_appOwner != address(0));
+        vm.assume(appOwner != address(0));
 
         vm.recordLogs();
 
-        Application app = factory.newApplication(
-            consensus,
-            _inputBox,
-            _inputRelays,
-            _appOwner,
-            _templateHash,
-            _salt
+        Application app = _factory.newApplication(
+            _consensus,
+            inputBox,
+            inputRelays,
+            appOwner,
+            templateHash,
+            salt
         );
 
-        testApplicationCreatedEventAux(
-            _inputBox,
-            _inputRelays,
-            _appOwner,
-            _templateHash,
+        _testApplicationCreatedEventAux(
+            inputBox,
+            inputRelays,
+            appOwner,
+            templateHash,
             app
         );
     }
 
-    function testApplicationCreatedEventAux(
-        IInputBox _inputBox,
-        IInputRelay[] calldata _inputRelays,
-        address _appOwner,
-        bytes32 _templateHash,
-        Application _app
+    function _testApplicationCreatedEventAux(
+        IInputBox inputBox,
+        IInputRelay[] calldata inputRelays,
+        address appOwner,
+        bytes32 templateHash,
+        Application app
     ) internal {
         Vm.Log[] memory entries = vm.getRecordedLogs();
 
@@ -177,7 +177,7 @@ contract ApplicationFactoryTest is TestBase {
             Vm.Log memory entry = entries[i];
 
             if (
-                entry.emitter == address(factory) &&
+                entry.emitter == address(_factory) &&
                 entry.topics[0] ==
                 IApplicationFactory.ApplicationCreated.selector
             ) {
@@ -185,15 +185,15 @@ contract ApplicationFactoryTest is TestBase {
 
                 assertEq(
                     entry.topics[1],
-                    bytes32(uint256(uint160(address(consensus))))
+                    bytes32(uint256(uint160(address(_consensus))))
                 );
 
                 (
-                    IInputBox inputBox,
-                    IInputRelay[] memory inputRelays,
-                    address appOwner,
-                    bytes32 templateHash,
-                    Application app
+                    IInputBox inputBox_,
+                    IInputRelay[] memory inputRelays_,
+                    address appOwner_,
+                    bytes32 templateHash_,
+                    Application app_
                 ) = abi.decode(
                         entry.data,
                         (
@@ -205,11 +205,11 @@ contract ApplicationFactoryTest is TestBase {
                         )
                     );
 
-                assertEq(address(_inputBox), address(inputBox));
-                assertEq(abi.encode(_inputRelays), abi.encode(inputRelays));
-                assertEq(_appOwner, appOwner);
-                assertEq(_templateHash, templateHash);
-                assertEq(address(_app), address(app));
+                assertEq(address(inputBox), address(inputBox_));
+                assertEq(abi.encode(inputRelays), abi.encode(inputRelays_));
+                assertEq(appOwner, appOwner_);
+                assertEq(templateHash, templateHash_);
+                assertEq(address(app), address(app_));
             }
         }
 

--- a/onchain/rollups/test/foundry/inputs/InputBox.t.sol
+++ b/onchain/rollups/test/foundry/inputs/InputBox.t.sol
@@ -11,89 +11,86 @@ import {CanonicalMachine} from "contracts/common/CanonicalMachine.sol";
 import {LibInput} from "contracts/library/LibInput.sol";
 
 contract InputBoxHandler is Test {
-    IInputBox immutable inputBox;
-
     struct InputData {
         address app;
         uint256 index;
         bytes32 inputHash;
     }
 
-    InputData[] inputDataArray;
+    IInputBox immutable _inputBox;
+    InputData[] _inputDataArray;
 
     // array of addresses of applications whose input boxes aren't empty
-    address[] apps;
-
+    address[] _apps;
     // mapping of application addresses to number of inputs
-    mapping(address => uint256) numOfInputs;
-
+    mapping(address => uint256) _numOfInputs;
     // block variables
-    uint256 blockTimestamp = block.timestamp;
-    uint256 blockNumber = block.number;
+    uint256 _blockTimestamp = block.timestamp;
+    uint256 _blockNumber = block.number;
 
-    constructor(IInputBox _inputBox) {
-        inputBox = _inputBox;
+    constructor(IInputBox inputBox) {
+        _inputBox = inputBox;
     }
 
     function incrementBlockTimestamp() external {
-        blockTimestamp++;
+        _blockTimestamp++;
     }
 
     function incrementBlockNumber() external {
-        blockNumber++;
+        _blockNumber++;
     }
 
-    function setBlockProperties() internal {
-        vm.warp(blockTimestamp);
-        vm.roll(blockNumber);
+    function _setBlockProperties() internal {
+        vm.warp(_blockTimestamp);
+        vm.roll(_blockNumber);
     }
 
-    function addInput(address _app, bytes calldata _input) external {
+    function addInput(address app, bytes calldata input) external {
         // For some reason, the invariant testing framework doesn't
         // record changes made to block properties, so we have to
         // set them in the beginning of every call
-        setBlockProperties();
+        _setBlockProperties();
 
         // Get the index of the to-be-added input
-        uint256 index = inputBox.getNumberOfInputs(_app);
+        uint256 index = _inputBox.getNumberOfInputs(app);
 
         // Check if `getNumberOfInputs` matches internal count
-        assertEq(index, numOfInputs[_app], "input box size");
+        assertEq(index, _numOfInputs[app], "input box size");
 
         // Make the sender add the input to the application's input box
         vm.prank(msg.sender);
-        bytes32 inputHash = inputBox.addInput(_app, _input);
+        bytes32 inputHash = _inputBox.addInput(app, input);
 
         // If this is the first input being added to the application's input box,
         // then push the application to the array of applications
         if (index == 0) {
-            apps.push(_app);
+            _apps.push(app);
         }
 
         // Increment the application's input count
-        ++numOfInputs[_app];
+        ++_numOfInputs[app];
 
         // Create the input data struct
         InputData memory inputData = InputData({
-            app: _app,
+            app: app,
             index: index,
             inputHash: inputHash
         });
 
         // Add the input data to the array
-        inputDataArray.push(inputData);
+        _inputDataArray.push(inputData);
 
         // Check if the input box size increases by one
         assertEq(
             index + 1,
-            inputBox.getNumberOfInputs(_app),
+            _inputBox.getNumberOfInputs(app),
             "input box size increment"
         );
 
         // Check if the input hash matches the one returned by `getInputHash`
         assertEq(
             inputHash,
-            inputBox.getInputHash(_app, index),
+            _inputBox.getInputHash(app, index),
             "returned input hash"
         );
 
@@ -102,7 +99,7 @@ contract InputBoxHandler is Test {
             msg.sender,
             block.number,
             block.timestamp,
-            _input,
+            input,
             index
         );
 
@@ -111,64 +108,64 @@ contract InputBoxHandler is Test {
     }
 
     function getTotalNumberOfInputs() external view returns (uint256) {
-        return inputDataArray.length;
+        return _inputDataArray.length;
     }
 
-    function getInputAt(uint256 _i) external view returns (InputData memory) {
-        return inputDataArray[_i];
+    function getInputAt(uint256 i) external view returns (InputData memory) {
+        return _inputDataArray[i];
     }
 
     function getNumberOfApplications() external view returns (uint256) {
-        return apps.length;
+        return _apps.length;
     }
 
-    function getApplicationAt(uint256 _i) external view returns (address) {
-        return apps[_i];
+    function getApplicationAt(uint256 i) external view returns (address) {
+        return _apps[i];
     }
 
-    function getNumberOfInputs(address _app) external view returns (uint256) {
-        return numOfInputs[_app];
+    function getNumberOfInputs(address app) external view returns (uint256) {
+        return _numOfInputs[app];
     }
 }
 
 contract InputBoxTest is Test {
     using CanonicalMachine for CanonicalMachine.Log2Size;
 
-    InputBox inputBox;
-    InputBoxHandler handler;
+    InputBox _inputBox;
+    InputBoxHandler _handler;
 
     function setUp() public {
-        inputBox = new InputBox();
-        handler = new InputBoxHandler(inputBox);
+        _inputBox = new InputBox();
+        _handler = new InputBoxHandler(_inputBox);
 
         // for the invariant testing,
         // don't call the input box contract directly
         // (do it through the handler contract)
-        excludeContract(address(inputBox));
+        excludeContract(address(_inputBox));
     }
 
-    function testNoInputs(address _app) public {
-        assertEq(inputBox.getNumberOfInputs(_app), 0);
+    function testNoInputs(address app) public {
+        assertEq(_inputBox.getNumberOfInputs(app), 0);
     }
 
     function testAddLargeInput() public {
         address app = vm.addr(1);
 
-        inputBox.addInput(app, new bytes(CanonicalMachine.INPUT_MAX_SIZE));
+        _inputBox.addInput(app, new bytes(CanonicalMachine.INPUT_MAX_SIZE));
 
         vm.expectRevert(LibInput.InputSizeExceedsLimit.selector);
-        inputBox.addInput(app, new bytes(CanonicalMachine.INPUT_MAX_SIZE + 1));
+        _inputBox.addInput(app, new bytes(CanonicalMachine.INPUT_MAX_SIZE + 1));
     }
 
     // fuzz testing with multiple inputs
-    function testAddInput(address _app, bytes[] calldata _inputs) public {
-        uint256 numInputs = _inputs.length;
+    function testAddInput(address app, bytes[] calldata inputs) public {
+        uint256 numInputs = inputs.length;
         bytes32[] memory returnedValues = new bytes32[](numInputs);
         uint256 year2022 = 1641070800; // Unix Timestamp for 2022
 
         // assume #bytes for each input is within bounds
         for (uint256 i; i < numInputs; ++i) {
-            vm.assume(_inputs[i].length <= CanonicalMachine.INPUT_MAX_SIZE);
+            vm.assume(inputs[i].length <= CanonicalMachine.INPUT_MAX_SIZE);
         }
 
         // adding inputs
@@ -178,15 +175,15 @@ contract InputBoxTest is Test {
             vm.warp(i + year2022); // year 2022
 
             // topics 1 and 2 are indexed; topic 3 isn't; check event data
-            vm.expectEmit(true, true, false, true, address(inputBox));
+            vm.expectEmit(true, true, false, true, address(_inputBox));
 
             // The event we expect
-            emit IInputBox.InputAdded(_app, i, address(this), _inputs[i]);
+            emit IInputBox.InputAdded(app, i, address(this), inputs[i]);
 
-            returnedValues[i] = inputBox.addInput(_app, _inputs[i]);
+            returnedValues[i] = _inputBox.addInput(app, inputs[i]);
 
             // test whether the number of inputs has increased
-            assertEq(i + 1, inputBox.getNumberOfInputs(_app));
+            assertEq(i + 1, _inputBox.getNumberOfInputs(app));
         }
 
         // testing added inputs
@@ -196,11 +193,11 @@ contract InputBoxTest is Test {
                 address(this),
                 i, // block.number
                 i + year2022, // block.timestamp
-                _inputs[i],
+                inputs[i],
                 i // inputBox.length
             );
             // test if input hash is the same as in InputBox
-            assertEq(inputHash, inputBox.getInputHash(_app, i));
+            assertEq(inputHash, _inputBox.getInputHash(app, i));
             // test if input hash is the same as returned from calling addInput() function
             assertEq(inputHash, returnedValues[i]);
         }
@@ -208,21 +205,21 @@ contract InputBoxTest is Test {
 
     function invariantInputData() external {
         // Get the total number of inputs
-        uint256 totalNumOfInputs = handler.getTotalNumberOfInputs();
+        uint256 totalNumOfInputs = _handler.getTotalNumberOfInputs();
 
         for (uint256 i; i < totalNumOfInputs; ++i) {
             // Get input data and metadata passed to `addInput`
-            InputBoxHandler.InputData memory inputData = handler.getInputAt(i);
+            InputBoxHandler.InputData memory inputData = _handler.getInputAt(i);
 
             // Make sure the input index is less than the input box size
             assertLt(
                 inputData.index,
-                inputBox.getNumberOfInputs(inputData.app),
+                _inputBox.getNumberOfInputs(inputData.app),
                 "index bound check"
             );
 
             // Get the input hash returned by `getInputHash`
-            bytes32 inputHash = inputBox.getInputHash(
+            bytes32 inputHash = _inputBox.getInputHash(
                 inputData.app,
                 inputData.index
             );
@@ -232,15 +229,15 @@ contract InputBoxTest is Test {
         }
 
         // Get the number of applications in the array
-        uint256 numOfApplications = handler.getNumberOfApplications();
+        uint256 numOfApplications = _handler.getNumberOfApplications();
 
         // Check the input box size of all the applications that
         // were interacted with, and sum them all up
         uint256 sum;
         for (uint256 i; i < numOfApplications; ++i) {
-            address app = handler.getApplicationAt(i);
-            uint256 expected = handler.getNumberOfInputs(app);
-            uint256 actual = inputBox.getNumberOfInputs(app);
+            address app = _handler.getApplicationAt(i);
+            uint256 expected = _handler.getNumberOfInputs(app);
+            uint256 actual = _inputBox.getNumberOfInputs(app);
             assertEq(expected, actual, "number of inputs for app");
             sum += actual;
         }

--- a/onchain/rollups/test/foundry/portals/ERC20Portal.t.sol
+++ b/onchain/rollups/test/foundry/portals/ERC20Portal.t.sol
@@ -171,25 +171,6 @@ contract ERC20PortalTest is Test {
         assertEq(token.balanceOf(address(_portal)), 0);
     }
 
-    function _encodeInput(
-        uint256 amount,
-        bytes calldata data
-    ) internal view returns (bytes memory) {
-        return InputEncoding.encodeERC20Deposit(_token, _alice, amount, data);
-    }
-
-    function _encodeTransferFrom(
-        uint256 amount
-    ) internal view returns (bytes memory) {
-        return abi.encodeCall(IERC20.transferFrom, (_alice, _app, amount));
-    }
-
-    function _encodeAddInput(
-        bytes memory _input
-    ) internal view returns (bytes memory) {
-        return abi.encodeCall(IInputBox.addInput, (_app, _input));
-    }
-
     function _testTokenReturns(
         uint256 amount,
         bytes calldata data,
@@ -211,5 +192,24 @@ contract ERC20PortalTest is Test {
 
         vm.prank(_alice);
         _portal.depositERC20Tokens(_token, _app, amount, data);
+    }
+
+    function _encodeInput(
+        uint256 amount,
+        bytes calldata data
+    ) internal view returns (bytes memory) {
+        return InputEncoding.encodeERC20Deposit(_token, _alice, amount, data);
+    }
+
+    function _encodeTransferFrom(
+        uint256 amount
+    ) internal view returns (bytes memory) {
+        return abi.encodeCall(IERC20.transferFrom, (_alice, _app, amount));
+    }
+
+    function _encodeAddInput(
+        bytes memory _input
+    ) internal view returns (bytes memory) {
+        return abi.encodeCall(IInputBox.addInput, (_app, _input));
     }
 }

--- a/onchain/rollups/test/foundry/relays/ApplicationAddressRelay.t.sol
+++ b/onchain/rollups/test/foundry/relays/ApplicationAddressRelay.t.sol
@@ -14,50 +14,50 @@ import {InputEncoding} from "contracts/common/InputEncoding.sol";
 import {IInputRelay} from "contracts/inputs/IInputRelay.sol";
 
 contract ApplicationAddressRelayTest is Test {
-    IInputBox inputBox;
-    IApplicationAddressRelay relay;
+    IInputBox _inputBox;
+    IApplicationAddressRelay _relay;
 
     function setUp() public {
-        inputBox = new InputBox();
-        relay = new ApplicationAddressRelay(inputBox);
+        _inputBox = new InputBox();
+        _relay = new ApplicationAddressRelay(_inputBox);
     }
 
-    function testSupportsInterface(bytes4 _randomInterfaceId) public {
+    function testSupportsInterface(bytes4 randomInterfaceId) public {
         assertTrue(
-            relay.supportsInterface(type(IApplicationAddressRelay).interfaceId)
+            _relay.supportsInterface(type(IApplicationAddressRelay).interfaceId)
         );
-        assertTrue(relay.supportsInterface(type(IInputRelay).interfaceId));
-        assertTrue(relay.supportsInterface(type(IERC165).interfaceId));
+        assertTrue(_relay.supportsInterface(type(IInputRelay).interfaceId));
+        assertTrue(_relay.supportsInterface(type(IERC165).interfaceId));
 
-        assertFalse(relay.supportsInterface(bytes4(0xffffffff)));
+        assertFalse(_relay.supportsInterface(bytes4(0xffffffff)));
 
         vm.assume(
-            _randomInterfaceId != type(IApplicationAddressRelay).interfaceId
+            randomInterfaceId != type(IApplicationAddressRelay).interfaceId
         );
-        vm.assume(_randomInterfaceId != type(IInputRelay).interfaceId);
-        vm.assume(_randomInterfaceId != type(IERC165).interfaceId);
-        assertFalse(relay.supportsInterface(_randomInterfaceId));
+        vm.assume(randomInterfaceId != type(IInputRelay).interfaceId);
+        vm.assume(randomInterfaceId != type(IERC165).interfaceId);
+        assertFalse(_relay.supportsInterface(randomInterfaceId));
     }
 
     function testGetInputBox() public {
-        assertEq(address(relay.getInputBox()), address(inputBox));
+        assertEq(address(_relay.getInputBox()), address(_inputBox));
     }
 
-    function testRelayApplicationAddress(address _app) public {
+    function testRelayApplicationAddress(address app) public {
         // Check the application's input box before
-        assertEq(inputBox.getNumberOfInputs(_app), 0);
+        assertEq(_inputBox.getNumberOfInputs(app), 0);
 
         // Construct the application address relay input
-        bytes memory input = abi.encodePacked(_app);
+        bytes memory input = abi.encodePacked(app);
 
         // Expect InputAdded to be emitted with the right arguments
-        vm.expectEmit(true, true, false, true, address(inputBox));
-        emit IInputBox.InputAdded(_app, 0, address(relay), input);
+        vm.expectEmit(true, true, false, true, address(_inputBox));
+        emit IInputBox.InputAdded(app, 0, address(_relay), input);
 
         // Relay the application's address
-        relay.relayApplicationAddress(_app);
+        _relay.relayApplicationAddress(app);
 
         // Check the application's input box after
-        assertEq(inputBox.getNumberOfInputs(_app), 1);
+        assertEq(_inputBox.getNumberOfInputs(app), 1);
     }
 }

--- a/onchain/rollups/test/foundry/util/LibServerManager.sol
+++ b/onchain/rollups/test/foundry/util/LibServerManager.sol
@@ -15,8 +15,6 @@ library LibServerManager {
     using LibServerManager for RawProof;
     using LibServerManager for RawProof[];
 
-    error InvalidOutputEnum(string);
-
     struct RawHash {
         bytes32 data;
     }
@@ -46,6 +44,39 @@ library LibServerManager {
         RawProof[] proofs;
         RawHash vouchersEpochRootHash;
     }
+
+    struct OutputValidityProof {
+        uint256 inputIndexWithinEpoch;
+        uint256 outputIndexWithinInput;
+        bytes32 outputHashesRootHash;
+        bytes32 vouchersEpochRootHash;
+        bytes32 noticesEpochRootHash;
+        bytes32 machineStateHash;
+        bytes32[] outputHashInOutputHashesSiblings;
+        bytes32[] outputHashesInEpochSiblings;
+    }
+
+    enum OutputEnum {
+        VOUCHER,
+        NOTICE
+    }
+
+    struct Proof {
+        uint256 inputIndex;
+        uint256 outputIndex;
+        OutputEnum outputEnum;
+        OutputValidityProof validity;
+        bytes context;
+    }
+
+    struct FinishEpochResponse {
+        bytes32 machineHash;
+        bytes32 vouchersEpochRootHash;
+        bytes32 noticesEpochRootHash;
+        Proof[] proofs;
+    }
+
+    error InvalidOutputEnum(string);
 
     function toUint(string memory s, Vm vm) internal pure returns (uint256) {
         return vm.parseUint(s);
@@ -138,37 +169,6 @@ library LibServerManager {
                 noticesEpochRootHash: r.noticesEpochRootHash.fmt(),
                 proofs: r.proofs.fmt(vm)
             });
-    }
-
-    struct OutputValidityProof {
-        uint256 inputIndexWithinEpoch;
-        uint256 outputIndexWithinInput;
-        bytes32 outputHashesRootHash;
-        bytes32 vouchersEpochRootHash;
-        bytes32 noticesEpochRootHash;
-        bytes32 machineStateHash;
-        bytes32[] outputHashInOutputHashesSiblings;
-        bytes32[] outputHashesInEpochSiblings;
-    }
-
-    enum OutputEnum {
-        VOUCHER,
-        NOTICE
-    }
-
-    struct Proof {
-        uint256 inputIndex;
-        uint256 outputIndex;
-        OutputEnum outputEnum;
-        OutputValidityProof validity;
-        bytes context;
-    }
-
-    struct FinishEpochResponse {
-        bytes32 machineHash;
-        bytes32 vouchersEpochRootHash;
-        bytes32 noticesEpochRootHash;
-        Proof[] proofs;
     }
 
     function getInputRange(


### PR DESCRIPTION
Following the [solidity style guide](https://docs.soliditylang.org/en/v0.8.23/style-guide.html), we made the following changes:

- remove prefix `_` for function parameters
- prefix `_` for internal/private state variables and functions, except for libraries, within which all functions are internal. For reference purpose, Openzeppelin also didn't prefix `_` for their [library](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/Address.sol).
- order functions and contract properties following the convention summarized [here](https://github.com/cartesi/rollups-contracts/issues/164#issuecomment-1882511525), with exceptions that if it’s easier to read otherwise