### PR TITLE
ci: tag changesets action by commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn install
 
       - name: Create release PR or publish to npm
-        uses: changesets/action@v1
+        uses: changesets/action@f13b1baaa620fde937751f5d2c3572b9da32af23
         with:
           commit: "chore: version packages"
           publish: yarn changeset publish


### PR DESCRIPTION
Tags and branches such as `v1` can be modified if the repository is compromised.
Commit hashes, on the other hand, are unfeasible to craft.
Let's adopt this security step whenever secrets (such as API tokens) are exposed to foreign actions.
Special thanks to @mpolitzer and @fmoura for the insight. :pray: