### PR TITLE
feat: move custom errors to interfaces

### DIFF
--- a/onchain/rollups/.changeset/hungry-months-walk.md
+++ b/onchain/rollups/.changeset/hungry-months-walk.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": minor
+---
+
+Added `EtherTransferFailed` error to `IEtherPortal` interface.

--- a/onchain/rollups/.changeset/modern-rats-build.md
+++ b/onchain/rollups/.changeset/modern-rats-build.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": minor
+---
+
+Added `ERC20TransferFailed` error to `IERC20Portal` interface.

--- a/onchain/rollups/.changeset/sweet-clouds-smoke.md
+++ b/onchain/rollups/.changeset/sweet-clouds-smoke.md
@@ -1,0 +1,10 @@
+---
+"@cartesi/rollups": minor
+---
+
+Added errors to `IApplication` interface:
+
+-   `VoucherReexecutionNotAllowed`
+-   `IncorrectEpochHash`
+-   `IncorrectOutputsEpochRootHash`
+-   `IncorrectOutputHashesRootHash`

--- a/onchain/rollups/contracts/dapp/Application.sol
+++ b/onchain/rollups/contracts/dapp/Application.sol
@@ -57,9 +57,6 @@ contract Application is
     /// @dev See the `getInputRelays` function.
     IInputRelay[] internal _inputRelays;
 
-    /// @notice Raised when executing an already executed voucher.
-    error VoucherReexecutionNotAllowed();
-
     /// @notice Raised when the transfer fails.
     error EtherTransferFailed();
 

--- a/onchain/rollups/contracts/dapp/IApplication.sol
+++ b/onchain/rollups/contracts/dapp/IApplication.sol
@@ -59,6 +59,21 @@ interface IApplication is IERC721Receiver, IERC1155Receiver {
     /// @param inputRange The input range
     error InputIndexOutOfRange(uint256 inputIndex, InputRange inputRange);
 
+    /// @notice Raised when executing an already executed voucher.
+    error VoucherReexecutionNotAllowed();
+
+    /// @notice Raised when some `OutputValidityProof` variables does not match
+    ///         the presented finalized epoch.
+    error IncorrectEpochHash();
+
+    /// @notice Raised when `OutputValidityProof` metadata memory range is NOT
+    ///         contained in epoch's output memory range.
+    error IncorrectOutputsEpochRootHash();
+
+    /// @notice Raised when Merkle root of output hash is NOT contained
+    ///         in the output metadata array memory range.
+    error IncorrectOutputHashesRootHash();
+
     // Permissioned functions
 
     /// @notice Migrate the application to a new consensus.

--- a/onchain/rollups/contracts/library/LibOutputValidation.sol
+++ b/onchain/rollups/contracts/library/LibOutputValidation.sol
@@ -4,6 +4,7 @@
 pragma solidity ^0.8.8;
 
 import {CanonicalMachine} from "../common/CanonicalMachine.sol";
+import {IApplication} from "../dapp/IApplication.sol";
 import {MerkleV2} from "@cartesi/util/contracts/MerkleV2.sol";
 import {OutputEncoding} from "../common/OutputEncoding.sol";
 import {OutputValidityProof} from "../common/OutputValidityProof.sol";
@@ -11,22 +12,6 @@ import {OutputValidityProof} from "../common/OutputValidityProof.sol";
 /// @title Output Validation Library
 library LibOutputValidation {
     using CanonicalMachine for CanonicalMachine.Log2Size;
-
-    /// @notice Raised when some `OutputValidityProof` variables does not match
-    ///         the presented finalized epoch.
-    error IncorrectEpochHash();
-
-    /// @notice Raised when `OutputValidityProof` metadata memory range is NOT
-    ///         contained in epoch's output memory range.
-    error IncorrectOutputsEpochRootHash();
-
-    /// @notice Raised when Merkle root of output hash is NOT contained
-    ///         in the output metadata array memory range.
-    error IncorrectOutputHashesRootHash();
-
-    /// @notice Raised when epoch input index is NOT compatible with the
-    ///         provided input index range.
-    error InputIndexOutOfClaimBounds();
 
     /// @notice Make sure the output proof is valid, otherwise revert.
     /// @param v The output validity proof
@@ -56,7 +41,7 @@ library LibOutputValidation {
                 )
             ) != epochHash
         ) {
-            revert IncorrectEpochHash();
+            revert IApplication.IncorrectEpochHash();
         }
 
         // prove that output metadata memory range is contained in epoch's output memory range
@@ -72,7 +57,7 @@ library LibOutputValidation {
                 v.outputHashesInEpochSiblings
             ) != outputsEpochRootHash
         ) {
-            revert IncorrectOutputsEpochRootHash();
+            revert IApplication.IncorrectOutputsEpochRootHash();
         }
 
         // The hash of the output is converted to bytes (abi.encode) and
@@ -111,7 +96,7 @@ library LibOutputValidation {
                 v.outputHashInOutputHashesSiblings
             ) != v.outputHashesRootHash
         ) {
-            revert IncorrectOutputHashesRootHash();
+            revert IApplication.IncorrectOutputHashesRootHash();
         }
     }
 
@@ -158,25 +143,5 @@ library LibOutputValidation {
             CanonicalMachine.EPOCH_NOTICE_LOG2_SIZE.uint64OfSize(),
             CanonicalMachine.NOTICE_METADATA_LOG2_SIZE.uint64OfSize()
         );
-    }
-
-    /// @notice Validate input index range and get the input index.
-    /// @param v The output validity proof
-    /// @param firstInputIndex The index of the first input of the epoch in the input box
-    /// @param lastInputIndex The index of the last input of the epoch in the input box
-    /// @return The index of the input in the application's input box
-    /// @dev Reverts if epoch input index is not compatible with the provided input index range.
-    function validateInputIndexRange(
-        OutputValidityProof calldata v,
-        uint256 firstInputIndex,
-        uint256 lastInputIndex
-    ) internal pure returns (uint256) {
-        uint256 inputIndex = firstInputIndex + v.inputIndexWithinEpoch;
-
-        if (inputIndex > lastInputIndex) {
-            revert InputIndexOutOfClaimBounds();
-        }
-
-        return inputIndex;
     }
 }

--- a/onchain/rollups/contracts/portals/IERC20Portal.sol
+++ b/onchain/rollups/contracts/portals/IERC20Portal.sol
@@ -8,6 +8,11 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /// @title ERC-20 Portal interface
 interface IERC20Portal is IInputRelay {
+    // Errors
+
+    /// @notice Failed to transfer ERC-20 tokens to application
+    error ERC20TransferFailed();
+
     // Permissionless functions
 
     /// @notice Transfer ERC-20 tokens to an application and add an input to

--- a/onchain/rollups/contracts/portals/IEtherPortal.sol
+++ b/onchain/rollups/contracts/portals/IEtherPortal.sol
@@ -7,6 +7,11 @@ import {IInputRelay} from "../inputs/IInputRelay.sol";
 
 /// @title Ether Portal interface
 interface IEtherPortal is IInputRelay {
+    // Errors
+
+    /// @notice Failed to transfer Ether to application
+    error EtherTransferFailed();
+
     // Permissionless functions
 
     /// @notice Transfer Ether to an application and add an input to
@@ -17,7 +22,7 @@ interface IEtherPortal is IInputRelay {
     /// @param app The address of the application
     /// @param execLayerData Additional data to be interpreted by the execution layer
     /// @dev All the value sent through this function is forwarded to the application.
-    ///      If the transfer fails, `EtherTransferFailed` error is raised.
+    ///      If the transfer fails, an `EtherTransferFailed` error is raised.
     function depositEther(
         address payable app,
         bytes calldata execLayerData

--- a/onchain/rollups/test/foundry/dapp/Application.t.sol
+++ b/onchain/rollups/test/foundry/dapp/Application.t.sol
@@ -194,9 +194,7 @@ contract ApplicationTest is TestBase {
 
         // reverts if notice is incorrect
         bytes memory falseNotice = abi.encodePacked(bytes4(0xdeaddead));
-        vm.expectRevert(
-            LibOutputValidation.IncorrectOutputHashesRootHash.selector
-        );
+        vm.expectRevert(IApplication.IncorrectOutputHashesRootHash.selector);
         _validateNotice(falseNotice, proof);
     }
 
@@ -265,7 +263,7 @@ contract ApplicationTest is TestBase {
         _executeVoucher(voucher, proof);
 
         // 2nd execution attempt should fail
-        vm.expectRevert(Application.VoucherReexecutionNotAllowed.selector);
+        vm.expectRevert(IApplication.VoucherReexecutionNotAllowed.selector);
         _executeVoucher(voucher, proof);
 
         // end result should be the same as executing successfully only once
@@ -332,7 +330,7 @@ contract ApplicationTest is TestBase {
 
         proof.validity.vouchersEpochRootHash = bytes32(uint256(0xdeadbeef));
 
-        vm.expectRevert(LibOutputValidation.IncorrectEpochHash.selector);
+        vm.expectRevert(IApplication.IncorrectEpochHash.selector);
         _executeVoucher(voucher, proof);
     }
 
@@ -344,9 +342,7 @@ contract ApplicationTest is TestBase {
 
         proof.validity.outputHashesRootHash = bytes32(uint256(0xdeadbeef));
 
-        vm.expectRevert(
-            LibOutputValidation.IncorrectOutputsEpochRootHash.selector
-        );
+        vm.expectRevert(IApplication.IncorrectOutputsEpochRootHash.selector);
         _executeVoucher(voucher, proof);
     }
 
@@ -358,9 +354,7 @@ contract ApplicationTest is TestBase {
 
         proof.validity.outputIndexWithinInput = 0xdeadbeef;
 
-        vm.expectRevert(
-            LibOutputValidation.IncorrectOutputHashesRootHash.selector
-        );
+        vm.expectRevert(IApplication.IncorrectOutputHashesRootHash.selector);
         _executeVoucher(voucher, proof);
     }
 
@@ -429,7 +423,7 @@ contract ApplicationTest is TestBase {
         assertEq(address(_recipient).balance, _transferAmount);
 
         // cannot execute the same voucher again
-        vm.expectRevert(Application.VoucherReexecutionNotAllowed.selector);
+        vm.expectRevert(IApplication.VoucherReexecutionNotAllowed.selector);
         _executeVoucher(voucher, proof);
     }
 
@@ -545,7 +539,7 @@ contract ApplicationTest is TestBase {
         assertEq(_erc721Token.ownerOf(_tokenId), _recipient);
 
         // cannot execute the same voucher again
-        vm.expectRevert(Application.VoucherReexecutionNotAllowed.selector);
+        vm.expectRevert(IApplication.VoucherReexecutionNotAllowed.selector);
         _executeVoucher(voucher, proof);
     }
 

--- a/onchain/rollups/test/foundry/portals/EtherPortal.t.sol
+++ b/onchain/rollups/test/foundry/portals/EtherPortal.t.sol
@@ -66,7 +66,7 @@ contract EtherPortalTest is Test {
         assertEq(_app.balance, balance + value);
     }
 
-    function testDepositFailedInnerCall(
+    function testDepositReverts(
         uint256 value,
         bytes calldata data,
         bytes calldata errorData
@@ -81,7 +81,7 @@ contract EtherPortalTest is Test {
 
         vm.mockCall(address(_inputBox), addInput, abi.encode(bytes32(0)));
 
-        vm.expectRevert(Address.FailedInnerCall.selector);
+        vm.expectRevert(IEtherPortal.EtherTransferFailed.selector);
 
         vm.deal(_alice, value);
         vm.prank(_alice);


### PR DESCRIPTION
Only two errors were kept in their respective contracts:

- `OnlyApplication`
- `EtherTransferFailed`

They were kept because they will soon be removed, along with the `withdrawEther` function.

Closes #206