### PR TITLE
refactor: use `abi.encode` and remove dead code

### DIFF
--- a/onchain/rollups/contracts/library/LibOutputValidation.sol
+++ b/onchain/rollups/contracts/library/LibOutputValidation.sol
@@ -24,9 +24,8 @@ library LibOutputValidation {
     ) internal pure {
         // prove that outputs hash is represented in a finalized epoch
         if (
-            keccak256(
-                abi.encodePacked(v.outputsEpochRootHash, v.machineStateHash)
-            ) != epochHash
+            keccak256(abi.encode(v.outputsEpochRootHash, v.machineStateHash)) !=
+            epochHash
         ) {
             revert IApplication.IncorrectEpochHash();
         }
@@ -65,7 +64,7 @@ library LibOutputValidation {
         // is contained in it. We can't simply use hashOfOutput because the
         // log2size of the leaf is three (8 bytes) not  five (32 bytes)
         bytes32 merkleRootOfHashOfOutput = MerkleV2.getMerkleRootFromBytes(
-            abi.encodePacked(keccak256(abi.encode(encodedOutput))),
+            abi.encode(keccak256(abi.encode(encodedOutput))),
             CanonicalMachine.KECCAK_LOG2_SIZE.uint64OfSize()
         );
 

--- a/onchain/rollups/test/foundry/dapp/Application.t.sol
+++ b/onchain/rollups/test/foundry/dapp/Application.t.sol
@@ -977,7 +977,7 @@ contract ApplicationTest is TestBase {
     ) internal pure returns (bytes32) {
         return
             keccak256(
-                abi.encodePacked(
+                abi.encode(
                     validity.outputsEpochRootHash,
                     validity.machineStateHash
                 )

--- a/onchain/rollups/test/foundry/util/LibServerManager.sol
+++ b/onchain/rollups/test/foundry/util/LibServerManager.sol
@@ -10,7 +10,6 @@ import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 library LibServerManager {
     using LibServerManager for string;
-    using LibServerManager for bytes32;
     using LibServerManager for RawHash;
     using LibServerManager for RawHash[];
     using LibServerManager for RawOutputValidityProof;
@@ -69,7 +68,6 @@ library LibServerManager {
         uint256 outputIndex;
         OutputEnum outputEnum;
         OutputValidityProof validity;
-        bytes context;
     }
 
     struct FinishEpochResponse {
@@ -131,10 +129,6 @@ library LibServerManager {
         }
     }
 
-    function toBytes(bytes32 b) internal pure returns (bytes memory) {
-        return abi.encodePacked(b);
-    }
-
     function fmt(
         RawProof memory p,
         Vm vm
@@ -144,8 +138,7 @@ library LibServerManager {
                 inputIndex: p.inputIndex.toUint(vm),
                 outputIndex: p.outputIndex.toUint(vm),
                 outputEnum: p.outputEnum.toOutputEnum(),
-                validity: p.validity.fmt(vm),
-                context: p.context.toBytes()
+                validity: p.validity.fmt(vm)
             });
     }
 


### PR DESCRIPTION
Closes #215 