### PR TITLE
refactor!: rename `LibOutputValidation` as `LibOutputValidityProof`

### DIFF
--- a/onchain/rollups/contracts/dapp/Application.sol
+++ b/onchain/rollups/contracts/dapp/Application.sol
@@ -7,7 +7,7 @@ import {IApplication} from "./IApplication.sol";
 import {IConsensus} from "../consensus/IConsensus.sol";
 import {IInputBox} from "../inputs/IInputBox.sol";
 import {IInputRelay} from "../inputs/IInputRelay.sol";
-import {LibOutputValidation} from "../library/LibOutputValidation.sol";
+import {LibOutputValidityProof} from "../library/LibOutputValidityProof.sol";
 import {OutputValidityProof} from "../common/OutputValidityProof.sol";
 import {Outputs} from "../common/Outputs.sol";
 import {InputRange} from "../common/InputRange.sol";
@@ -31,7 +31,7 @@ contract Application is
 {
     using BitMaps for BitMaps.BitMap;
     using LibError for bytes;
-    using LibOutputValidation for OutputValidityProof;
+    using LibOutputValidityProof for OutputValidityProof;
     using LibInputRange for InputRange;
 
     /// @notice The initial machine state hash.

--- a/onchain/rollups/contracts/library/LibOutputValidityProof.sol
+++ b/onchain/rollups/contracts/library/LibOutputValidityProof.sol
@@ -8,8 +8,7 @@ import {MerkleV2} from "@cartesi/util/contracts/MerkleV2.sol";
 import {Outputs} from "../common/Outputs.sol";
 import {OutputValidityProof} from "../common/OutputValidityProof.sol";
 
-/// @title Output Validation Library
-library LibOutputValidation {
+library LibOutputValidityProof {
     using CanonicalMachine for CanonicalMachine.Log2Size;
 
     /// @notice Check if epoch hash is valid

--- a/onchain/rollups/test/foundry/dapp/Application.t.sol
+++ b/onchain/rollups/test/foundry/dapp/Application.t.sol
@@ -11,7 +11,7 @@ import {IApplication} from "contracts/dapp/IApplication.sol";
 import {IConsensus} from "contracts/consensus/IConsensus.sol";
 import {IInputBox} from "contracts/inputs/IInputBox.sol";
 import {IInputRelay} from "contracts/inputs/IInputRelay.sol";
-import {LibOutputValidation} from "contracts/library/LibOutputValidation.sol";
+import {LibOutputValidityProof} from "contracts/library/LibOutputValidityProof.sol";
 import {OutputValidityProof} from "contracts/common/OutputValidityProof.sol";
 import {Outputs} from "contracts/common/Outputs.sol";
 import {InputRange} from "contracts/common/InputRange.sol";
@@ -37,7 +37,7 @@ contract ApplicationTest is TestBase {
     using LibServerManager for LibServerManager.RawFinishEpochResponse;
     using LibServerManager for LibServerManager.Proof;
     using LibServerManager for LibServerManager.Proof[];
-    using LibOutputValidation for OutputValidityProof;
+    using LibOutputValidityProof for OutputValidityProof;
     using SafeCast for uint256;
 
     enum OutputName {


### PR DESCRIPTION
Close #214 