### PR TITLE
chore: adjust changeset files

### DIFF
--- a/onchain/rollups/.changeset/fast-tips-push.md
+++ b/onchain/rollups/.changeset/fast-tips-push.md
@@ -1,6 +1,0 @@
----
-"@cartesi/rollups": major
----
-
-Renamed `IInputRelay` as `IPortal` and `InputRelay` as `Portal`.
-Moved those 2 contracts to the folder `portals`.

--- a/onchain/rollups/.changeset/fifty-keys-tickle.md
+++ b/onchain/rollups/.changeset/fifty-keys-tickle.md
@@ -7,5 +7,5 @@ Modified the `EtherPortal` contract:
 -   Made it support the following interfaces (as in EIP-165):
 
     -   `IERC165`
-    -   `IInputRelay`
+    -   `IPortal`
     -   `IEtherPortal`

--- a/onchain/rollups/.changeset/lazy-gorillas-scream.md
+++ b/onchain/rollups/.changeset/lazy-gorillas-scream.md
@@ -4,4 +4,8 @@
 
 Modified the `IInputRelay` interface:
 
+-   Renamed it as `IPortal`
+
+-   Moved it to `contracts/portals`
+
 -   Made it inherit from `IERC165`

--- a/onchain/rollups/.changeset/lemon-rivers-nail.md
+++ b/onchain/rollups/.changeset/lemon-rivers-nail.md
@@ -7,5 +7,5 @@ Modified the `ERC1155BatchPortal` contract:
 -   Made it support the following interfaces (as in EIP-165):
 
     -   `IERC165`
-    -   `IInputRelay`
+    -   `IPortal`
     -   `IERC1155BatchPortal`

--- a/onchain/rollups/.changeset/quiet-guests-greet.md
+++ b/onchain/rollups/.changeset/quiet-guests-greet.md
@@ -9,4 +9,4 @@ Modified the `ICartesiDAppFactory` interface:
 -   Added the following parameters to its functions and events:
 
     -   `inputBox`
-    -   `inputRelays`
+    -   `portals`

--- a/onchain/rollups/.changeset/red-wasps-report.md
+++ b/onchain/rollups/.changeset/red-wasps-report.md
@@ -9,7 +9,7 @@ Modified the `CartesiDApp` contract:
 -   Added the following parameters to its constructor:
 
     -   `inputBox`
-    -   `inputRelays`
+    -   `portals`
 
 -   Made it support the following interfaces (as in EIP-165):
 

--- a/onchain/rollups/.changeset/rude-scissors-try.md
+++ b/onchain/rollups/.changeset/rude-scissors-try.md
@@ -7,5 +7,5 @@ Modified the `ERC1155SinglePortal` contract:
 -   Made it support the following interfaces (as in EIP-165):
 
     -   `IERC165`
-    -   `IInputRelay`
+    -   `IPortal`
     -   `IERC1155SinglePortal`

--- a/onchain/rollups/.changeset/seven-teachers-behave.md
+++ b/onchain/rollups/.changeset/seven-teachers-behave.md
@@ -12,5 +12,5 @@ Removed:
 -   the `IAuthorityHistoryPairFactory` interface.
 -   the `OutputEncoding` library.
 -   the `LibInput` library.
--   the `ApplicationAddressRelay` contract.
--   the `IApplicationAddressRelay` interface.
+-   the `DAppAddressRelay` contract.
+-   the `IDAppAddressRelay` interface.

--- a/onchain/rollups/.changeset/silly-islands-end.md
+++ b/onchain/rollups/.changeset/silly-islands-end.md
@@ -36,7 +36,7 @@ Modified the `ICartesiDApp` interface:
 
 -   Added a `getInputBox` function.
 
--   Added a `getInputRelays` function.
+-   Added a `getPortals` function.
 
 -   Added an `InputIndexOutOfRange` error.
 

--- a/onchain/rollups/.changeset/smooth-ducks-trade.md
+++ b/onchain/rollups/.changeset/smooth-ducks-trade.md
@@ -4,7 +4,11 @@
 
 Modified the `InputRelay` contract:
 
+-   Renamed it as `Portal`
+
+-   Moved it to `contracts/portals`
+
 -   Made it support the following interfaces (as in EIP-165):
 
     -   `IERC165`
-    -   `IInputRelay`
+    -   `IPortal`

--- a/onchain/rollups/.changeset/two-mails-marry.md
+++ b/onchain/rollups/.changeset/two-mails-marry.md
@@ -7,5 +7,5 @@ Modified the `ERC20Portal` contract:
 -   Made it support the following interfaces (as in EIP-165):
 
     -   `IERC165`
-    -   `IInputRelay`
+    -   `IPortal`
     -   `IERC20Portal`

--- a/onchain/rollups/.changeset/wise-owls-push.md
+++ b/onchain/rollups/.changeset/wise-owls-push.md
@@ -7,5 +7,5 @@ Modified the `ERC721Portal` contract:
 -   Made it support the following interfaces (as in EIP-165):
 
     -   `IERC165`
-    -   `IInputRelay`
+    -   `IPortal`
     -   `IERC721Portal`


### PR DESCRIPTION
- `IInputRelay` -> `IPortal`
- `InputRelay` -> `Portal`
- `inputRelays` -> `portals`
- `getInputRelays` -> `getPortals`
- `DAppAddressRelay` was removed, not renamed