### PR TITLE
Edit `Inputs` interface

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -77,13 +77,13 @@ The Application Factory allows anyone to deploy `Application` contracts with a s
 
 ### Portals
 
-Portals, as the name suggests, are used to safely teleport assets from the base layer to the execution layer. It works in the following way. First, for some types of assets, the user has to allow the portal to deduct the asset(s) from their account. Second, the user tells the portal to transfer the asset(s) from their account to some application's account. The portal then adds an input to the application's input box to inform the machine of the transfer that just took place in the base layer. Finally, the off-chain machine is made aware of the transfer through the input sent by the portal. Note that the machine must know the address of the portal beforehand in order to validate such input.
+Portals, as the name suggests, are used to safely teleport assets from the base layer to the execution layer. It works in the following way. First, for some types of assets, the user has to allow the portal to deduct the asset(s) from their account. Second, the user tells the portal to transfer the asset(s) from their account to the application's account. The portal then adds an input to the application's input box to inform the machine of the transfer that just took place in the base layer. Finally, the off-chain machine is made aware of the transfer through the input sent by the portal. Note that the machine must know the address of the portal beforehand in order to validate such input.
 
 The application developer can choose to do whatever they want with this information. For example, they might choose to create a wallet for each user in the execution layer, where assets can be managed at a much lower cost through inputs that are understood by the Linux logic. In this sense, one could think of the application contract as a wallet, owned by the off-chain machine. Anyone can deposit assets there but only the application—through vouchers—can decide on withdrawals.
 
 The withdrawal process is quite simple from the user's perspective. Typically, the user would first send an input to the application requesting the withdrawal, which would then get processed and interpreted off-chain. If all goes well, the machine should generate a voucher that, once executed, transfers the asset(s) to the rightful recipient.
 
-Currently, we support the following types of assets:
+Currently, the following types of assets are supported:
 
 - [Ether](https://ethereum.org/en/eth/) (ETH)
 - [ERC-20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) (Fungible tokens)
@@ -114,7 +114,7 @@ As an example, the deposit of 100 Wei (of Ether) sent by address `0xf39fd6e51aad
 
 Vouchers allow applications in the execution layer to interact with contracts in the base layer through message calls. They are emitted by the off-chain machine, and can be executed by anyone in the base layer. Each voucher is composed of a destination address, a value, and a payload. In the case of vouchers destined to Solidity contracts, the payload generally encodes a function call. Moreover, the value field denotes the amount of Wei to be passed along the message call to the destination, which can be used for Ether withdrawals and for payable function calls.
 
-A voucher can only be executed once the application's consensus accepts a claim containing it. They can be executed in any order. Although the application contract is indifferent to the content of the voucher being executed, it enforces some sanity checks before allowing its execution. First, it checks whether the voucher has been successfully executed already. Second, it ensures that the voucher has been emitted by the off-chain machine, by requiring a validity proof.
+A voucher can only be executed once the application's consensus accepts a claim containing it. They can be executed in any order. Although the application contract is indifferent to the content of the voucher being executed, it enforces some sanity checks before allowing its execution. First, it makes sure the voucher hasn't been executed yet. Second, it ensures that the voucher has been emitted by the off-chain machine by checking the provided validity proof.
 
 Because of their generality, vouchers can be used in a wide range of applications: from withdrawing funds to providing liquidity in DeFi protocols. Typically, applications use vouchers to withdraw assets. Below, we show how vouchers can be used to withdraw several types of assets. You can find more information about a particular function by clicking on the :page_facing_up: emoji near it.
 

--- a/contracts/common/Inputs.sol
+++ b/contracts/common/Inputs.sol
@@ -23,8 +23,4 @@ interface Inputs {
         uint256 index,
         bytes calldata payload
     ) external;
-
-    /// @notice An inspect request to a Cartesi Machine.
-    /// @param payload The inspect payload
-    function EvmInspect(bytes calldata payload) external;
 }

--- a/contracts/common/Inputs.sol
+++ b/contracts/common/Inputs.sol
@@ -9,15 +9,15 @@ interface Inputs {
     /// @notice An advance request from an EVM-compatible blockchain to a Cartesi Machine.
     /// @param chainId The chain ID
     /// @param app The application address
-    /// @param sender The address of whoever sent the input
+    /// @param msgSender The address of whoever sent the input
     /// @param blockNumber The number of the block in which the input was added
     /// @param blockTimestamp The timestamp of the block in which the input was added
     /// @param index The input index
-    /// @param payload The payload provided by the sender
+    /// @param payload The payload provided by the message sender
     function EvmAdvance(
         uint256 chainId,
         address app,
-        address sender,
+        address msgSender,
         uint256 blockNumber,
         uint256 blockTimestamp,
         uint256 index,

--- a/contracts/common/Inputs.sol
+++ b/contracts/common/Inputs.sol
@@ -8,7 +8,7 @@ pragma solidity ^0.8.8;
 interface Inputs {
     /// @notice An advance request from an EVM-compatible blockchain to a Cartesi Machine.
     /// @param chainId The chain ID
-    /// @param app The application address
+    /// @param appContract The application contract address
     /// @param msgSender The address of whoever sent the input
     /// @param blockNumber The number of the block in which the input was added
     /// @param blockTimestamp The timestamp of the block in which the input was added
@@ -16,7 +16,7 @@ interface Inputs {
     /// @param payload The payload provided by the message sender
     function EvmAdvance(
         uint256 chainId,
-        address app,
+        address appContract,
         address msgSender,
         uint256 blockNumber,
         uint256 blockTimestamp,

--- a/contracts/common/Inputs.sol
+++ b/contracts/common/Inputs.sol
@@ -12,7 +12,7 @@ interface Inputs {
     /// @param msgSender The address of whoever sent the input
     /// @param blockNumber The number of the block in which the input was added
     /// @param blockTimestamp The timestamp of the block in which the input was added
-    /// @param index The input index
+    /// @param index The index of the input in the input box
     /// @param payload The payload provided by the message sender
     function EvmAdvance(
         uint256 chainId,

--- a/contracts/consensus/AbstractConsensus.sol
+++ b/contracts/consensus/AbstractConsensus.sol
@@ -10,34 +10,34 @@ import {InputRange} from "../common/InputRange.sol";
 /// @dev This contract was designed to be inherited by implementations of the `IConsensus` interface
 /// that only need a simple mechanism of storage and retrieval of epoch hashes.
 abstract contract AbstractConsensus is IConsensus {
-    /// @notice Indexes epoch hashes by application address, first input index and last input index.
+    /// @notice Indexes epoch hashes by application contract address, first input index and last input index.
     mapping(address => mapping(uint256 => mapping(uint256 => bytes32)))
         private _epochHashes;
 
     /// @notice Get the epoch hash for a certain application and input range.
-    /// @param app The application contract address
+    /// @param appContract The application contract address
     /// @param r The input range
     /// @return epochHash The epoch hash
     /// @dev For claimed epochs, returns the epoch hash of the last accepted claim.
     /// @dev For unclaimed epochs, returns `bytes32(0)`.
     function getEpochHash(
-        address app,
+        address appContract,
         InputRange calldata r
     ) public view override returns (bytes32 epochHash) {
-        epochHash = _epochHashes[app][r.firstIndex][r.lastIndex];
+        epochHash = _epochHashes[appContract][r.firstIndex][r.lastIndex];
     }
 
     /// @notice Accept a claim.
-    /// @param app The application contract address
+    /// @param appContract The application contract address
     /// @param r The input range
     /// @param epochHash The epoch hash
     /// @dev On successs, emits a `ClaimAcceptance` event.
     function _acceptClaim(
-        address app,
+        address appContract,
         InputRange calldata r,
         bytes32 epochHash
     ) internal {
-        _epochHashes[app][r.firstIndex][r.lastIndex] = epochHash;
-        emit ClaimAcceptance(app, r, epochHash);
+        _epochHashes[appContract][r.firstIndex][r.lastIndex] = epochHash;
+        emit ClaimAcceptance(appContract, r, epochHash);
     }
 }

--- a/contracts/consensus/IConsensus.sol
+++ b/contracts/consensus/IConsensus.sol
@@ -8,7 +8,7 @@ import {InputRange} from "../common/InputRange.sol";
 /// @notice Provides data availability of epoch hashes for applications.
 /// @notice An epoch hash is produced after the machine processes a range of inputs and the epoch is finalized.
 /// This hash can be later used to prove that any given output was produced by the machine during the epoch.
-/// @notice After an epoch is finalized, a validator may submit a claim containing the application address,
+/// @notice After an epoch is finalized, a validator may submit a claim containing the application contract address,
 /// the range of inputs accepted during the epoch, and the epoch hash.
 /// @notice Validators may synchronize epoch finalization, but such mechanism is not specified by this interface.
 /// @notice A validator should be able to save transaction fees by not submitting a claim if it was...
@@ -22,49 +22,49 @@ import {InputRange} from "../common/InputRange.sol";
 interface IConsensus {
     /// @notice MUST trigger when a claim is submitted.
     /// @param submitter The submitter address
-    /// @param app The application address
+    /// @param appContract The application contract address
     /// @param inputRange The input range
     /// @param epochHash The epoch hash
-    /// @dev Overwrites any previous submissions regarding `submitter`, `app` and `inputRange`.
+    /// @dev Overwrites any previous submissions regarding `submitter`, `appContract` and `inputRange`.
     event ClaimSubmission(
         address indexed submitter,
-        address indexed app,
+        address indexed appContract,
         InputRange inputRange,
         bytes32 epochHash
     );
 
     /// @notice MUST trigger when a claim is accepted.
-    /// @param app The application address
+    /// @param appContract The application contract address
     /// @param inputRange The input range
     /// @param epochHash The epoch hash
-    /// @dev MUST be triggered after some `ClaimSubmission` event regarding `app`, `inputRange` and `epochHash`.
-    /// @dev Overwrites any previous acceptances regarding `app` and `inputRange`.
+    /// @dev MUST be triggered after some `ClaimSubmission` event regarding `appContract`, `inputRange` and `epochHash`.
+    /// @dev Overwrites any previous acceptances regarding `appContract` and `inputRange`.
     event ClaimAcceptance(
-        address indexed app,
+        address indexed appContract,
         InputRange inputRange,
         bytes32 epochHash
     );
 
     /// @notice Submit a claim to the consensus.
-    /// @param app The application address
+    /// @param appContract The application contract address
     /// @param inputRange The input range
     /// @param epochHash The epoch hash
     /// @dev MUST fire a `ClaimSubmission` event.
     /// @dev MAY fire a `ClaimAcceptance` event, if the acceptance criteria is met.
     function submitClaim(
-        address app,
+        address appContract,
         InputRange calldata inputRange,
         bytes32 epochHash
     ) external;
 
     /// @notice Get the epoch hash for a certain application and input range.
-    /// @param app The application address
+    /// @param appContract The application contract address
     /// @param inputRange The input range
     /// @return epochHash The epoch hash
     /// @dev For claimed epochs, must return the epoch hash of the last accepted claim.
     /// @dev For unclaimed epochs, MUST either revert or return `bytes32(0)`.
     function getEpochHash(
-        address app,
+        address appContract,
         InputRange calldata inputRange
     ) external view returns (bytes32 epochHash);
 }

--- a/contracts/consensus/authority/Authority.sol
+++ b/contracts/consensus/authority/Authority.sol
@@ -17,17 +17,17 @@ contract Authority is AbstractConsensus, Ownable {
     constructor(address initialOwner) Ownable(initialOwner) {}
 
     /// @notice Submit a claim.
-    /// @param app The application contract address
+    /// @param appContract The application contract address
     /// @param inputRange The input range
     /// @param epochHash The epoch hash
     /// @dev Fires a `ClaimSubmission` event and a `ClaimAcceptance` event.
     /// @dev Can only be called by the owner.
     function submitClaim(
-        address app,
+        address appContract,
         InputRange calldata inputRange,
         bytes32 epochHash
     ) external override onlyOwner {
-        emit ClaimSubmission(msg.sender, app, inputRange, epochHash);
-        _acceptClaim(app, inputRange, epochHash);
+        emit ClaimSubmission(msg.sender, appContract, inputRange, epochHash);
+        _acceptClaim(appContract, inputRange, epochHash);
     }
 }

--- a/contracts/consensus/quorum/Quorum.sol
+++ b/contracts/consensus/quorum/Quorum.sol
@@ -42,7 +42,7 @@ contract Quorum is AbstractConsensus {
     }
 
     /// @notice Votes indexed by claim
-    /// (application address, first input index, last input index, and epoch hash).
+    /// (application contract address, first input index, last input index, and epoch hash).
     /// @dev See the `numOfValidatorsInFavorOf` and `isValidatorInFavorOf` functions.
     mapping(address => mapping(uint256 => mapping(uint256 => mapping(bytes32 => Votes))))
         private _votes;
@@ -64,26 +64,26 @@ contract Quorum is AbstractConsensus {
 
     /// @notice Submit a claim.
     /// @notice If the majority of the quorum submit a claim, it is accepted.
-    /// @param app The application address
+    /// @param appContract The application contract address
     /// @param r The input range
     /// @param epochHash The epoch hash
     /// @dev Can only be called by a validator.
     function submitClaim(
-        address app,
+        address appContract,
         InputRange calldata r,
         bytes32 epochHash
     ) external {
         uint256 id = _validatorId[msg.sender];
         require(id > 0, "Quorum: caller is not validator");
 
-        emit ClaimSubmission(msg.sender, app, r, epochHash);
+        emit ClaimSubmission(msg.sender, appContract, r, epochHash);
 
-        Votes storage votes = _getVotes(app, r, epochHash);
+        Votes storage votes = _getVotes(appContract, r, epochHash);
 
         if (!votes.inFavorById.get(id)) {
             votes.inFavorById.set(id);
             if (++votes.inFavorCount == 1 + _numOfValidators / 2) {
-                _acceptClaim(app, r, epochHash);
+                _acceptClaim(appContract, r, epochHash);
             }
         }
     }
@@ -110,44 +110,44 @@ contract Quorum is AbstractConsensus {
     }
 
     /// @notice Get the number of validators in favor of a claim.
-    /// @param app The application address
+    /// @param appContract The application contract address
     /// @param r The input range
     /// @param epochHash The epoch hash
     /// @return Number of validators in favor of claim
     function numOfValidatorsInFavorOf(
-        address app,
+        address appContract,
         InputRange calldata r,
         bytes32 epochHash
     ) external view returns (uint256) {
-        return _getVotes(app, r, epochHash).inFavorCount;
+        return _getVotes(appContract, r, epochHash).inFavorCount;
     }
 
     /// @notice Check whether a validator is in favor of a claim.
-    /// @param app The application address
+    /// @param appContract The application contract address
     /// @param r The input range
     /// @param epochHash The epoch hash
     /// @param id The ID of the validator
     /// @return Whether validator is in favor of claim
     /// @dev Assumes the provided ID is valid.
     function isValidatorInFavorOf(
-        address app,
+        address appContract,
         InputRange calldata r,
         bytes32 epochHash,
         uint256 id
     ) external view returns (bool) {
-        return _getVotes(app, r, epochHash).inFavorById.get(id);
+        return _getVotes(appContract, r, epochHash).inFavorById.get(id);
     }
 
     /// @notice Get a `Votes` structure from storage from a given claim.
-    /// @param app The application address
+    /// @param appContract The application contract address
     /// @param r The input range
     /// @param epochHash The epoch hash
     /// @return The `Votes` structure related to given claim
     function _getVotes(
-        address app,
+        address appContract,
         InputRange calldata r,
         bytes32 epochHash
     ) internal view returns (Votes storage) {
-        return _votes[app][r.firstIndex][r.lastIndex][epochHash];
+        return _votes[appContract][r.firstIndex][r.lastIndex][epochHash];
     }
 }

--- a/contracts/dapp/Application.sol
+++ b/contracts/dapp/Application.sol
@@ -175,8 +175,7 @@ contract Application is
             super.supportsInterface(interfaceId);
     }
 
-    /// @notice Get the epoch hash regarding the given input range
-    /// and the application from the current consensus.
+    /// @notice Get the epoch hash regarding an input range from the current consensus.
     /// @param inputRange The input range
     /// @return The epoch hash
     function _getEpochHash(

--- a/contracts/dapp/ApplicationFactory.sol
+++ b/contracts/dapp/ApplicationFactory.sol
@@ -21,7 +21,7 @@ contract ApplicationFactory is IApplicationFactory {
         address appOwner,
         bytes32 templateHash
     ) external override returns (Application) {
-        Application app = new Application(
+        Application appContract = new Application(
             consensus,
             inputBox,
             portals,
@@ -35,10 +35,10 @@ contract ApplicationFactory is IApplicationFactory {
             portals,
             appOwner,
             templateHash,
-            app
+            appContract
         );
 
-        return app;
+        return appContract;
     }
 
     function newApplication(
@@ -49,7 +49,7 @@ contract ApplicationFactory is IApplicationFactory {
         bytes32 templateHash,
         bytes32 salt
     ) external override returns (Application) {
-        Application app = new Application{salt: salt}(
+        Application appContract = new Application{salt: salt}(
             consensus,
             inputBox,
             portals,
@@ -63,10 +63,10 @@ contract ApplicationFactory is IApplicationFactory {
             portals,
             appOwner,
             templateHash,
-            app
+            appContract
         );
 
-        return app;
+        return appContract;
     }
 
     function calculateApplicationAddress(

--- a/contracts/dapp/IApplicationFactory.sol
+++ b/contracts/dapp/IApplicationFactory.sol
@@ -18,7 +18,7 @@ interface IApplicationFactory {
     /// @param portals The portals supported by the application
     /// @param appOwner The initial application owner
     /// @param templateHash The initial machine state hash
-    /// @param app The application
+    /// @param appContract The application contract
     /// @dev MUST be triggered on a successful call to `newApplication`.
     event ApplicationCreated(
         IConsensus indexed consensus,
@@ -26,7 +26,7 @@ interface IApplicationFactory {
         IPortal[] portals,
         address appOwner,
         bytes32 templateHash,
-        Application app
+        Application appContract
     );
 
     // Permissionless functions
@@ -53,7 +53,7 @@ interface IApplicationFactory {
     /// @param portals The portals supported by the application
     /// @param appOwner The initial application owner
     /// @param templateHash The initial machine state hash
-    /// @param salt The salt used to deterministically generate the application address
+    /// @param salt The salt used to deterministically generate the application contract address
     /// @return The application
     /// @dev On success, MUST emit an `ApplicationCreated` event.
     function newApplication(
@@ -65,14 +65,14 @@ interface IApplicationFactory {
         bytes32 salt
     ) external returns (Application);
 
-    /// @notice Calculate the address of an application to be deployed deterministically.
+    /// @notice Calculate the address of an application contract to be deployed deterministically.
     /// @param consensus The initial consensus contract
     /// @param inputBox The input box contract
     /// @param portals The portals supported by the application
     /// @param appOwner The initial application owner
     /// @param templateHash The initial machine state hash
-    /// @param salt The salt used to deterministically generate the application address
-    /// @return The deterministic application address
+    /// @param salt The salt used to deterministically generate the application contract address
+    /// @return The deterministic application contract address
     /// @dev Beware that only the `newApplication` function with the `salt` parameter
     ///      is able to deterministically deploy an application.
     function calculateApplicationAddress(

--- a/contracts/inputs/IInputBox.sol
+++ b/contracts/inputs/IInputBox.sol
@@ -5,46 +5,52 @@ pragma solidity ^0.8.8;
 
 /// @notice Provides data availability of inputs for applications.
 /// @notice Each application has its own append-only list of inputs.
-/// @notice Off-chain, inputs can be reconstructed from events.
+/// @notice Off-chain, inputs can be retrieved via events.
 /// @notice On-chain, only the input hashes are stored.
 /// @notice See `LibInput` for more details on how such hashes are computed.
 interface IInputBox {
     /// @notice MUST trigger when an input is added.
-    /// @param app The application address
+    /// @param appContract The application contract address
     /// @param index The input index
     /// @param input The input blob
-    event InputAdded(address indexed app, uint256 indexed index, bytes input);
+    event InputAdded(
+        address indexed appContract,
+        uint256 indexed index,
+        bytes input
+    );
 
     /// @notice Input is too large.
-    /// @param app The application address
+    /// @param appContract The application contract address
     /// @param inputLength The input length
     /// @param maxInputLength The maximum input length
     error InputTooLarge(
-        address app,
+        address appContract,
         uint256 inputLength,
         uint256 maxInputLength
     );
 
     /// @notice Send an input to an application.
-    /// @param app The application address
+    /// @param appContract The application contract address
     /// @param payload The input payload
     /// @return The hash of the input blob
     /// @dev MUST fire an `InputAdded` event.
     function addInput(
-        address app,
+        address appContract,
         bytes calldata payload
     ) external returns (bytes32);
 
     /// @notice Get the number of inputs sent to an application.
-    /// @param app The application address
-    function getNumberOfInputs(address app) external view returns (uint256);
+    /// @param appContract The application contract address
+    function getNumberOfInputs(
+        address appContract
+    ) external view returns (uint256);
 
     /// @notice Get the hash of an input in an application's input box.
-    /// @param app The application address
+    /// @param appContract The application contract address
     /// @param index The input index
     /// @dev The provided index must be valid.
     function getInputHash(
-        address app,
+        address appContract,
         uint256 index
     ) external view returns (bytes32);
 }

--- a/contracts/inputs/InputBox.sol
+++ b/contracts/inputs/InputBox.sol
@@ -8,15 +8,15 @@ import {CanonicalMachine} from "../common/CanonicalMachine.sol";
 import {Inputs} from "../common/Inputs.sol";
 
 contract InputBox is IInputBox {
-    /// @notice Mapping of application addresses to arrays of input hashes.
+    /// @notice Mapping of application contract addresses to arrays of input hashes.
     mapping(address => bytes32[]) private _inputBoxes;
 
     /// @inheritdoc IInputBox
     function addInput(
-        address app,
+        address appContract,
         bytes calldata payload
     ) external override returns (bytes32) {
-        bytes32[] storage inputBox = _inputBoxes[app];
+        bytes32[] storage inputBox = _inputBoxes[appContract];
 
         uint256 index = inputBox.length;
 
@@ -24,7 +24,7 @@ contract InputBox is IInputBox {
             Inputs.EvmAdvance,
             (
                 block.chainid,
-                app,
+                appContract,
                 msg.sender,
                 block.number,
                 block.timestamp,
@@ -35,7 +35,7 @@ contract InputBox is IInputBox {
 
         if (input.length > CanonicalMachine.INPUT_MAX_SIZE) {
             revert InputTooLarge(
-                app,
+                appContract,
                 input.length,
                 CanonicalMachine.INPUT_MAX_SIZE
             );
@@ -45,23 +45,23 @@ contract InputBox is IInputBox {
 
         inputBox.push(inputHash);
 
-        emit InputAdded(app, index, input);
+        emit InputAdded(appContract, index, input);
 
         return inputHash;
     }
 
     /// @inheritdoc IInputBox
     function getNumberOfInputs(
-        address app
+        address appContract
     ) external view override returns (uint256) {
-        return _inputBoxes[app].length;
+        return _inputBoxes[appContract].length;
     }
 
     /// @inheritdoc IInputBox
     function getInputHash(
-        address app,
+        address appContract,
         uint256 index
     ) external view override returns (bytes32) {
-        return _inputBoxes[app][index];
+        return _inputBoxes[appContract][index];
     }
 }

--- a/contracts/portals/ERC1155BatchPortal.sol
+++ b/contracts/portals/ERC1155BatchPortal.sol
@@ -14,7 +14,7 @@ import {InputEncoding} from "../common/InputEncoding.sol";
 /// @title ERC-1155 Batch Transfer Portal
 ///
 /// @notice This contract allows anyone to perform batch transfers of
-/// ERC-1155 tokens to an application while informing the off-chain machine.
+/// ERC-1155 tokens to an application contract while informing the off-chain machine.
 contract ERC1155BatchPortal is IERC1155BatchPortal, Portal {
     /// @notice Constructs the portal.
     /// @param inputBox The input box used by the portal
@@ -22,7 +22,7 @@ contract ERC1155BatchPortal is IERC1155BatchPortal, Portal {
 
     function depositBatchERC1155Token(
         IERC1155 token,
-        address app,
+        address appContract,
         uint256[] calldata tokenIds,
         uint256[] calldata values,
         bytes calldata baseLayerData,
@@ -30,7 +30,7 @@ contract ERC1155BatchPortal is IERC1155BatchPortal, Portal {
     ) external override {
         token.safeBatchTransferFrom(
             msg.sender,
-            app,
+            appContract,
             tokenIds,
             values,
             baseLayerData
@@ -45,7 +45,7 @@ contract ERC1155BatchPortal is IERC1155BatchPortal, Portal {
             execLayerData
         );
 
-        _inputBox.addInput(app, payload);
+        _inputBox.addInput(appContract, payload);
     }
 
     function supportsInterface(

--- a/contracts/portals/ERC1155SinglePortal.sol
+++ b/contracts/portals/ERC1155SinglePortal.sol
@@ -14,7 +14,7 @@ import {InputEncoding} from "../common/InputEncoding.sol";
 /// @title ERC-1155 Single Transfer Portal
 ///
 /// @notice This contract allows anyone to perform single transfers of
-/// ERC-1155 tokens to an application while informing the off-chain machine.
+/// ERC-1155 tokens to an application contract while informing the off-chain machine.
 contract ERC1155SinglePortal is IERC1155SinglePortal, Portal {
     /// @notice Constructs the portal.
     /// @param inputBox The input box used by the portal
@@ -22,13 +22,19 @@ contract ERC1155SinglePortal is IERC1155SinglePortal, Portal {
 
     function depositSingleERC1155Token(
         IERC1155 token,
-        address app,
+        address appContract,
         uint256 tokenId,
         uint256 value,
         bytes calldata baseLayerData,
         bytes calldata execLayerData
     ) external override {
-        token.safeTransferFrom(msg.sender, app, tokenId, value, baseLayerData);
+        token.safeTransferFrom(
+            msg.sender,
+            appContract,
+            tokenId,
+            value,
+            baseLayerData
+        );
 
         bytes memory payload = InputEncoding.encodeSingleERC1155Deposit(
             token,
@@ -39,7 +45,7 @@ contract ERC1155SinglePortal is IERC1155SinglePortal, Portal {
             execLayerData
         );
 
-        _inputBox.addInput(app, payload);
+        _inputBox.addInput(appContract, payload);
     }
 
     function supportsInterface(

--- a/contracts/portals/ERC20Portal.sol
+++ b/contracts/portals/ERC20Portal.sol
@@ -14,7 +14,7 @@ import {InputEncoding} from "../common/InputEncoding.sol";
 /// @title ERC-20 Portal
 ///
 /// @notice This contract allows anyone to perform transfers of
-/// ERC-20 tokens to an application while informing the off-chain machine.
+/// ERC-20 tokens to an application contract while informing the off-chain machine.
 contract ERC20Portal is IERC20Portal, Portal {
     /// @notice Constructs the portal.
     /// @param inputBox The input box used by the portal
@@ -22,11 +22,11 @@ contract ERC20Portal is IERC20Portal, Portal {
 
     function depositERC20Tokens(
         IERC20 token,
-        address app,
+        address appContract,
         uint256 amount,
         bytes calldata execLayerData
     ) external override {
-        bool success = token.transferFrom(msg.sender, app, amount);
+        bool success = token.transferFrom(msg.sender, appContract, amount);
 
         if (!success) {
             revert ERC20TransferFailed();
@@ -39,7 +39,7 @@ contract ERC20Portal is IERC20Portal, Portal {
             execLayerData
         );
 
-        _inputBox.addInput(app, payload);
+        _inputBox.addInput(appContract, payload);
     }
 
     function supportsInterface(

--- a/contracts/portals/ERC721Portal.sol
+++ b/contracts/portals/ERC721Portal.sol
@@ -14,7 +14,7 @@ import {InputEncoding} from "../common/InputEncoding.sol";
 /// @title ERC-721 Portal
 ///
 /// @notice This contract allows anyone to perform transfers of
-/// ERC-721 tokens to an application while informing the off-chain machine.
+/// ERC-721 tokens to an application contract while informing the off-chain machine.
 contract ERC721Portal is IERC721Portal, Portal {
     /// @notice Constructs the portal.
     /// @param inputBox The input box used by the portal
@@ -22,12 +22,12 @@ contract ERC721Portal is IERC721Portal, Portal {
 
     function depositERC721Token(
         IERC721 token,
-        address app,
+        address appContract,
         uint256 tokenId,
         bytes calldata baseLayerData,
         bytes calldata execLayerData
     ) external override {
-        token.safeTransferFrom(msg.sender, app, tokenId, baseLayerData);
+        token.safeTransferFrom(msg.sender, appContract, tokenId, baseLayerData);
 
         bytes memory payload = InputEncoding.encodeERC721Deposit(
             token,
@@ -37,7 +37,7 @@ contract ERC721Portal is IERC721Portal, Portal {
             execLayerData
         );
 
-        _inputBox.addInput(app, payload);
+        _inputBox.addInput(appContract, payload);
     }
 
     function supportsInterface(

--- a/contracts/portals/EtherPortal.sol
+++ b/contracts/portals/EtherPortal.sol
@@ -13,17 +13,17 @@ import {InputEncoding} from "../common/InputEncoding.sol";
 /// @title Ether Portal
 ///
 /// @notice This contract allows anyone to perform transfers of
-/// Ether to an application while informing the off-chain machine.
+/// Ether to an application contract while informing the off-chain machine.
 contract EtherPortal is IEtherPortal, Portal {
     /// @notice Constructs the portal.
     /// @param inputBox The input box used by the portal
     constructor(IInputBox inputBox) Portal(inputBox) {}
 
     function depositEther(
-        address app,
+        address appContract,
         bytes calldata execLayerData
     ) external payable override {
-        (bool success, ) = app.call{value: msg.value}("");
+        (bool success, ) = appContract.call{value: msg.value}("");
 
         if (!success) {
             revert EtherTransferFailed();
@@ -35,7 +35,7 @@ contract EtherPortal is IEtherPortal, Portal {
             execLayerData
         );
 
-        _inputBox.addInput(app, payload);
+        _inputBox.addInput(appContract, payload);
     }
 
     function supportsInterface(

--- a/contracts/portals/IERC1155BatchPortal.sol
+++ b/contracts/portals/IERC1155BatchPortal.sol
@@ -10,23 +10,23 @@ import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 interface IERC1155BatchPortal is IPortal {
     // Permissionless functions
 
-    /// @notice Transfer a batch of ERC-1155 tokens to an application and add an input to
-    /// the application's input box to signal such operation.
+    /// @notice Transfer a batch of ERC-1155 tokens of multiple types to an application contract
+    /// and add an input to the application's input box to signal such operation.
     ///
     /// The caller must enable approval for the portal to manage all of their tokens
     /// beforehand, by calling the `setApprovalForAll` function in the token contract.
     ///
     /// @param token The ERC-1155 token contract
-    /// @param app The address of the application
+    /// @param appContract The application contract address
     /// @param tokenIds The identifiers of the tokens being transferred
     /// @param values Transfer amounts per token type
     /// @param baseLayerData Additional data to be interpreted by the base layer
     /// @param execLayerData Additional data to be interpreted by the execution layer
     ///
-    /// @dev Please make sure `tokenIds` and `values` have the same length.
+    /// @dev Please make sure the arrays `tokenIds` and `values` have the same length.
     function depositBatchERC1155Token(
         IERC1155 token,
-        address app,
+        address appContract,
         uint256[] calldata tokenIds,
         uint256[] calldata values,
         bytes calldata baseLayerData,

--- a/contracts/portals/IERC1155SinglePortal.sol
+++ b/contracts/portals/IERC1155SinglePortal.sol
@@ -10,21 +10,21 @@ import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 interface IERC1155SinglePortal is IPortal {
     // Permissionless functions
 
-    /// @notice Transfer an ERC-1155 token to an application and add an input to
-    /// the application's input box to signal such operation.
+    /// @notice Transfer ERC-1155 tokens of a single type to an application contract
+    /// and add an input to the application's input box to signal such operation.
     ///
     /// The caller must enable approval for the portal to manage all of their tokens
     /// beforehand, by calling the `setApprovalForAll` function in the token contract.
     ///
     /// @param token The ERC-1155 token contract
-    /// @param app The address of the application
+    /// @param appContract The application contract address
     /// @param tokenId The identifier of the token being transferred
     /// @param value Transfer amount
     /// @param baseLayerData Additional data to be interpreted by the base layer
     /// @param execLayerData Additional data to be interpreted by the execution layer
     function depositSingleERC1155Token(
         IERC1155 token,
-        address app,
+        address appContract,
         uint256 tokenId,
         uint256 value,
         bytes calldata baseLayerData,

--- a/contracts/portals/IERC20Portal.sol
+++ b/contracts/portals/IERC20Portal.sol
@@ -15,20 +15,20 @@ interface IERC20Portal is IPortal {
 
     // Permissionless functions
 
-    /// @notice Transfer ERC-20 tokens to an application and add an input to
-    /// the application's input box to signal such operation.
+    /// @notice Transfer ERC-20 tokens to an application contract
+    /// and add an input to the application's input box to signal such operation.
     ///
     /// The caller must allow the portal to withdraw at least `amount` tokens
     /// from their account beforehand, by calling the `approve` function in the
     /// token contract.
     ///
     /// @param token The ERC-20 token contract
-    /// @param app The address of the application
+    /// @param appContract The application contract address
     /// @param amount The amount of tokens to be transferred
     /// @param execLayerData Additional data to be interpreted by the execution layer
     function depositERC20Tokens(
         IERC20 token,
-        address app,
+        address appContract,
         uint256 amount,
         bytes calldata execLayerData
     ) external;

--- a/contracts/portals/IERC721Portal.sol
+++ b/contracts/portals/IERC721Portal.sol
@@ -10,21 +10,21 @@ import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 interface IERC721Portal is IPortal {
     // Permissionless functions
 
-    /// @notice Transfer an ERC-721 token to an application and add an input to
-    /// the application's input box to signal such operation.
+    /// @notice Transfer an ERC-721 token to an application contract
+    /// and add an input to the application's input box to signal such operation.
     ///
     /// The caller must change the approved address for the ERC-721 token
     /// to the portal address beforehand, by calling the `approve` function in the
     /// token contract.
     ///
     /// @param token The ERC-721 token contract
-    /// @param app The address of the application
+    /// @param appContract The application contract address
     /// @param tokenId The identifier of the token being transferred
     /// @param baseLayerData Additional data to be interpreted by the base layer
     /// @param execLayerData Additional data to be interpreted by the execution layer
     function depositERC721Token(
         IERC721 token,
-        address app,
+        address appContract,
         uint256 tokenId,
         bytes calldata baseLayerData,
         bytes calldata execLayerData

--- a/contracts/portals/IEtherPortal.sol
+++ b/contracts/portals/IEtherPortal.sol
@@ -14,17 +14,16 @@ interface IEtherPortal is IPortal {
 
     // Permissionless functions
 
-    /// @notice Transfer Ether to an application and add an input to
-    /// the application's input box to signal such operation.
+    /// @notice Transfer Ether to an application contract
+    /// and add an input to the application's input box to signal such operation.
     ///
-    /// All the value sent through this function is forwarded to the application.
-    ///
-    /// @param app The address of the application
+    /// @param appContract The application contract address
     /// @param execLayerData Additional data to be interpreted by the execution layer
-    /// @dev All the value sent through this function is forwarded to the application.
-    ///      If the transfer fails, an `EtherTransferFailed` error is raised.
+    ///
+    /// @dev Any Ether sent through this function will be forwarded to the application contract.
+    ///      If the transfer fails, an `EtherTransferFailed` error will be raised.
     function depositEther(
-        address app,
+        address appContract,
         bytes calldata execLayerData
     ) external payable;
 }

--- a/test/foundry/consensus/authority/Authority.t.sol
+++ b/test/foundry/consensus/authority/Authority.t.sol
@@ -63,7 +63,7 @@ contract AuthorityTest is TestBase {
     function testSubmitClaimRevertsCallerNotOwner(
         address owner,
         address notOwner,
-        address app,
+        address appContract,
         InputRange calldata inputRange,
         bytes32 epochHash
     ) public {
@@ -80,12 +80,12 @@ contract AuthorityTest is TestBase {
         );
 
         vm.prank(notOwner);
-        authority.submitClaim(app, inputRange, epochHash);
+        authority.submitClaim(appContract, inputRange, epochHash);
     }
 
     function testSubmitClaim(
         address owner,
-        address app,
+        address appContract,
         InputRange calldata inputRange,
         bytes32[2] calldata epochHashes
     ) public {
@@ -95,46 +95,69 @@ contract AuthorityTest is TestBase {
 
         // First claim
 
-        _expectClaimEvents(authority, owner, app, inputRange, epochHashes[0]);
+        _expectClaimEvents(
+            authority,
+            owner,
+            appContract,
+            inputRange,
+            epochHashes[0]
+        );
 
         vm.prank(owner);
-        authority.submitClaim(app, inputRange, epochHashes[0]);
+        authority.submitClaim(appContract, inputRange, epochHashes[0]);
 
-        assertEq(authority.getEpochHash(app, inputRange), epochHashes[0]);
+        assertEq(
+            authority.getEpochHash(appContract, inputRange),
+            epochHashes[0]
+        );
 
         // Second claim
 
-        _expectClaimEvents(authority, owner, app, inputRange, epochHashes[1]);
+        _expectClaimEvents(
+            authority,
+            owner,
+            appContract,
+            inputRange,
+            epochHashes[1]
+        );
 
         vm.prank(owner);
-        authority.submitClaim(app, inputRange, epochHashes[1]);
+        authority.submitClaim(appContract, inputRange, epochHashes[1]);
 
-        assertEq(authority.getEpochHash(app, inputRange), epochHashes[1]);
+        assertEq(
+            authority.getEpochHash(appContract, inputRange),
+            epochHashes[1]
+        );
     }
 
     function testGetEpochHash(
         address owner,
-        address app,
+        address appContract,
         InputRange calldata inputRange
     ) public {
         vm.assume(owner != address(0));
 
         Authority authority = new Authority(owner);
 
-        assertEq(authority.getEpochHash(app, inputRange), bytes32(0));
+        assertEq(authority.getEpochHash(appContract, inputRange), bytes32(0));
     }
 
     function _expectClaimEvents(
         Authority authority,
         address owner,
-        address app,
+        address appContract,
         InputRange calldata inputRange,
         bytes32 epochHash
     ) internal {
         vm.expectEmit(true, true, false, true, address(authority));
-        emit IConsensus.ClaimSubmission(owner, app, inputRange, epochHash);
+        emit IConsensus.ClaimSubmission(
+            owner,
+            appContract,
+            inputRange,
+            epochHash
+        );
 
         vm.expectEmit(true, false, false, true, address(authority));
-        emit IConsensus.ClaimAcceptance(app, inputRange, epochHash);
+        emit IConsensus.ClaimAcceptance(appContract, inputRange, epochHash);
     }
 }

--- a/test/foundry/consensus/quorum/Quorum.t.sol
+++ b/test/foundry/consensus/quorum/Quorum.t.sol
@@ -13,7 +13,7 @@ import {LibTopic} from "../../util/LibTopic.sol";
 import {Vm} from "forge-std/Vm.sol";
 
 struct Claim {
-    address dapp;
+    address appContract;
     InputRange inputRange;
     bytes32 epochHash;
 }
@@ -25,7 +25,7 @@ library LibQuorum {
     ) internal view returns (uint256) {
         return
             quorum.numOfValidatorsInFavorOf(
-                claim.dapp,
+                claim.appContract,
                 claim.inputRange,
                 claim.epochHash
             );
@@ -38,7 +38,7 @@ library LibQuorum {
     ) internal view returns (bool) {
         return
             quorum.isValidatorInFavorOf(
-                claim.dapp,
+                claim.appContract,
                 claim.inputRange,
                 claim.epochHash,
                 id
@@ -46,7 +46,11 @@ library LibQuorum {
     }
 
     function submitClaim(Quorum quorum, Claim calldata claim) internal {
-        quorum.submitClaim(claim.dapp, claim.inputRange, claim.epochHash);
+        quorum.submitClaim(
+            claim.appContract,
+            claim.inputRange,
+            claim.epochHash
+        );
     }
 }
 
@@ -248,7 +252,7 @@ contract QuorumTest is TestBase {
                 );
 
                 assertEq(entry.topics[1], validator.asTopic());
-                assertEq(entry.topics[2], claim.dapp.asTopic());
+                assertEq(entry.topics[2], claim.appContract.asTopic());
                 assertEq(inputRange, claim.inputRange);
                 assertEq(epochHash, claim.epochHash);
 
@@ -264,7 +268,7 @@ contract QuorumTest is TestBase {
                     (InputRange, bytes32)
                 );
 
-                assertEq(entry.topics[1], claim.dapp.asTopic());
+                assertEq(entry.topics[1], claim.appContract.asTopic());
                 assertEq(inputRange, claim.inputRange);
                 assertEq(epochHash, claim.epochHash);
 
@@ -285,7 +289,7 @@ contract QuorumTest is TestBase {
 
         if (inFavorCount > (numOfValidators / 2)) {
             assertEq(
-                quorum.getEpochHash(claim.dapp, claim.inputRange),
+                quorum.getEpochHash(claim.appContract, claim.inputRange),
                 claim.epochHash
             );
         }

--- a/test/foundry/dapp/ApplicationFactory.t.sol
+++ b/test/foundry/dapp/ApplicationFactory.t.sol
@@ -28,7 +28,7 @@ contract ApplicationFactoryTest is TestBase {
     ) public {
         vm.assume(appOwner != address(0));
 
-        Application app = _factory.newApplication(
+        Application appContract = _factory.newApplication(
             consensus,
             inputBox,
             portals,
@@ -36,12 +36,12 @@ contract ApplicationFactoryTest is TestBase {
             templateHash
         );
 
-        assertEq(address(app.getConsensus()), address(consensus));
-        assertEq(address(app.getInputBox()), address(inputBox));
+        assertEq(address(appContract.getConsensus()), address(consensus));
+        assertEq(address(appContract.getInputBox()), address(inputBox));
         // abi.encode is used instead of a loop
-        assertEq(abi.encode(app.getPortals()), abi.encode(portals));
-        assertEq(app.owner(), appOwner);
-        assertEq(app.getTemplateHash(), templateHash);
+        assertEq(abi.encode(appContract.getPortals()), abi.encode(portals));
+        assertEq(appContract.owner(), appOwner);
+        assertEq(appContract.getTemplateHash(), templateHash);
     }
 
     function testNewApplicationDeterministic(
@@ -63,7 +63,7 @@ contract ApplicationFactoryTest is TestBase {
             salt
         );
 
-        Application app = _factory.newApplication(
+        Application appContract = _factory.newApplication(
             consensus,
             inputBox,
             portals,
@@ -73,13 +73,13 @@ contract ApplicationFactoryTest is TestBase {
         );
 
         // Precalculated address must match actual address
-        assertEq(precalculatedAddress, address(app));
+        assertEq(precalculatedAddress, address(appContract));
 
-        assertEq(address(app.getConsensus()), address(consensus));
-        assertEq(address(app.getInputBox()), address(inputBox));
-        assertEq(abi.encode(app.getPortals()), abi.encode(portals));
-        assertEq(app.owner(), appOwner);
-        assertEq(app.getTemplateHash(), templateHash);
+        assertEq(address(appContract.getConsensus()), address(consensus));
+        assertEq(address(appContract.getInputBox()), address(inputBox));
+        assertEq(abi.encode(appContract.getPortals()), abi.encode(portals));
+        assertEq(appContract.owner(), appOwner);
+        assertEq(appContract.getTemplateHash(), templateHash);
 
         precalculatedAddress = _factory.calculateApplicationAddress(
             consensus,
@@ -91,7 +91,7 @@ contract ApplicationFactoryTest is TestBase {
         );
 
         // Precalculated address must STILL match actual address
-        assertEq(precalculatedAddress, address(app));
+        assertEq(precalculatedAddress, address(appContract));
 
         // Cannot deploy an application with the same salt twice
         vm.expectRevert(bytes(""));
@@ -116,7 +116,7 @@ contract ApplicationFactoryTest is TestBase {
 
         vm.recordLogs();
 
-        Application app = _factory.newApplication(
+        Application appContract = _factory.newApplication(
             consensus,
             inputBox,
             portals,
@@ -130,7 +130,7 @@ contract ApplicationFactoryTest is TestBase {
             portals,
             appOwner,
             templateHash,
-            app
+            appContract
         );
     }
 
@@ -146,7 +146,7 @@ contract ApplicationFactoryTest is TestBase {
 
         vm.recordLogs();
 
-        Application app = _factory.newApplication(
+        Application appContract = _factory.newApplication(
             consensus,
             inputBox,
             portals,
@@ -161,7 +161,7 @@ contract ApplicationFactoryTest is TestBase {
             portals,
             appOwner,
             templateHash,
-            app
+            appContract
         );
     }
 
@@ -171,7 +171,7 @@ contract ApplicationFactoryTest is TestBase {
         IPortal[] calldata portals,
         address appOwner,
         bytes32 templateHash,
-        Application app
+        Application appContract
     ) internal {
         Vm.Log[] memory entries = vm.getRecordedLogs();
 
@@ -207,7 +207,7 @@ contract ApplicationFactoryTest is TestBase {
                 assertEq(abi.encode(portals), abi.encode(portals_));
                 assertEq(appOwner, appOwner_);
                 assertEq(templateHash, templateHash_);
-                assertEq(address(app), address(app_));
+                assertEq(address(appContract), address(app_));
             }
         }
 

--- a/test/foundry/inputs/InputBox.t.sol
+++ b/test/foundry/inputs/InputBox.t.sol
@@ -18,34 +18,34 @@ contract InputBoxTest is Test {
         _inputBox = new InputBox();
     }
 
-    function testNoInputs(address app) public {
-        assertEq(_inputBox.getNumberOfInputs(app), 0);
+    function testNoInputs(address appContract) public {
+        assertEq(_inputBox.getNumberOfInputs(appContract), 0);
     }
 
     function testAddLargeInput() public {
-        address app = vm.addr(1);
+        address appContract = vm.addr(1);
         uint256 max = _getMaxInputPayloadLength();
 
-        _inputBox.addInput(app, new bytes(max));
+        _inputBox.addInput(appContract, new bytes(max));
 
         bytes memory largePayload = new bytes(max + 1);
         uint256 largeLength = EvmAdvanceEncoder
-            .encode(1, app, address(this), 1, largePayload)
+            .encode(1, appContract, address(this), 1, largePayload)
             .length;
         vm.expectRevert(
             abi.encodeWithSelector(
                 IInputBox.InputTooLarge.selector,
-                app,
+                appContract,
                 largeLength,
                 CanonicalMachine.INPUT_MAX_SIZE
             )
         );
-        _inputBox.addInput(app, largePayload);
+        _inputBox.addInput(appContract, largePayload);
     }
 
     function testAddInput(
         uint64 chainId,
-        address app,
+        address appContract,
         bytes[] calldata payloads
     ) public {
         vm.chainId(chainId); // foundry limits chain id to be less than 2^64 - 1
@@ -68,16 +68,16 @@ contract InputBoxTest is Test {
             vm.expectEmit(true, true, false, true, address(_inputBox));
             bytes memory input = EvmAdvanceEncoder.encode(
                 chainId,
-                app,
+                appContract,
                 address(this),
                 i,
                 payloads[i]
             );
-            emit IInputBox.InputAdded(app, i, input);
+            emit IInputBox.InputAdded(appContract, i, input);
 
-            returnedValues[i] = _inputBox.addInput(app, payloads[i]);
+            returnedValues[i] = _inputBox.addInput(appContract, payloads[i]);
 
-            assertEq(i + 1, _inputBox.getNumberOfInputs(app));
+            assertEq(i + 1, _inputBox.getNumberOfInputs(appContract));
         }
 
         // testing added inputs
@@ -87,7 +87,7 @@ contract InputBoxTest is Test {
                     Inputs.EvmAdvance,
                     (
                         chainId,
-                        app,
+                        appContract,
                         address(this),
                         i, // block.number
                         i + year2022, // block.timestamp
@@ -97,7 +97,7 @@ contract InputBoxTest is Test {
                 )
             );
             // test if input hash is the same as in InputBox
-            assertEq(inputHash, _inputBox.getInputHash(app, i));
+            assertEq(inputHash, _inputBox.getInputHash(appContract, i));
             // test if input hash is the same as returned from calling addInput() function
             assertEq(inputHash, returnedValues[i]);
         }

--- a/test/foundry/portals/ERC1155BatchPortal.t.sol
+++ b/test/foundry/portals/ERC1155BatchPortal.t.sol
@@ -26,14 +26,14 @@ contract NormalToken is ERC1155 {
 
 contract ERC1155BatchPortalTest is ERC165Test {
     address _alice;
-    address _app;
+    address _appContract;
     IERC1155 _token;
     IInputBox _inputBox;
     IERC1155BatchPortal _portal;
 
     function setUp() public {
         _alice = vm.addr(1);
-        _app = vm.addr(2);
+        _appContract = vm.addr(2);
         _token = IERC1155(vm.addr(3));
         _inputBox = IInputBox(vm.addr(4));
         _portal = new ERC1155BatchPortal(_inputBox);
@@ -89,7 +89,7 @@ contract ERC1155BatchPortalTest is ERC165Test {
         vm.prank(_alice);
         _portal.depositBatchERC1155Token(
             _token,
-            _app,
+            _appContract,
             tokenIds,
             values,
             baseLayerData,
@@ -129,7 +129,7 @@ contract ERC1155BatchPortalTest is ERC165Test {
         vm.prank(_alice);
         _portal.depositBatchERC1155Token(
             _token,
-            _app,
+            _appContract,
             tokenIds,
             values,
             baseLayerData,
@@ -175,7 +175,7 @@ contract ERC1155BatchPortalTest is ERC165Test {
             uint256 tokenId = tokenIds[i];
             uint256 supply = supplies[i];
             assertEq(_token.balanceOf(_alice, tokenId), supply);
-            assertEq(_token.balanceOf(_app, tokenId), 0);
+            assertEq(_token.balanceOf(_appContract, tokenId), 0);
             assertEq(_token.balanceOf(address(_portal), tokenId), 0);
         }
 
@@ -185,14 +185,14 @@ contract ERC1155BatchPortalTest is ERC165Test {
         emit IERC1155.TransferBatch(
             address(_portal),
             _alice,
-            _app,
+            _appContract,
             tokenIds,
             values
         );
 
         _portal.depositBatchERC1155Token(
             _token,
-            _app,
+            _appContract,
             tokenIds,
             values,
             baseLayerData,
@@ -206,7 +206,7 @@ contract ERC1155BatchPortalTest is ERC165Test {
             uint256 value = values[i];
             uint256 supply = supplies[i];
             assertEq(_token.balanceOf(_alice, tokenId), supply - value);
-            assertEq(_token.balanceOf(_app, tokenId), value);
+            assertEq(_token.balanceOf(_appContract, tokenId), value);
             assertEq(_token.balanceOf(address(_portal), tokenId), 0);
         }
     }
@@ -231,7 +231,7 @@ contract ERC1155BatchPortalTest is ERC165Test {
     function _encodeAddInput(
         bytes memory payload
     ) internal view returns (bytes memory) {
-        return abi.encodeCall(IInputBox.addInput, (_app, payload));
+        return abi.encodeCall(IInputBox.addInput, (_appContract, payload));
     }
 
     function _encodeSafeBatchTransferFrom(
@@ -242,7 +242,7 @@ contract ERC1155BatchPortalTest is ERC165Test {
         return
             abi.encodeCall(
                 IERC1155.safeBatchTransferFrom,
-                (_alice, _app, tokenIds, values, baseLayerData)
+                (_alice, _appContract, tokenIds, values, baseLayerData)
             );
     }
 }

--- a/test/foundry/portals/ERC1155SinglePortal.t.sol
+++ b/test/foundry/portals/ERC1155SinglePortal.t.sol
@@ -26,14 +26,14 @@ contract NormalToken is ERC1155 {
 
 contract ERC1155SinglePortalTest is ERC165Test {
     address _alice;
-    address _app;
+    address _appContract;
     IERC1155 _token;
     IInputBox _inputBox;
     IERC1155SinglePortal _portal;
 
     function setUp() public {
         _alice = vm.addr(1);
-        _app = vm.addr(2);
+        _appContract = vm.addr(2);
         _token = IERC1155(vm.addr(3));
         _inputBox = IInputBox(vm.addr(4));
         _portal = new ERC1155SinglePortal(_inputBox);
@@ -89,7 +89,7 @@ contract ERC1155SinglePortalTest is ERC165Test {
         vm.prank(_alice);
         _portal.depositSingleERC1155Token(
             _token,
-            _app,
+            _appContract,
             tokenId,
             value,
             baseLayerData,
@@ -129,7 +129,7 @@ contract ERC1155SinglePortalTest is ERC165Test {
         vm.prank(_alice);
         _portal.depositSingleERC1155Token(
             _token,
-            _app,
+            _appContract,
             tokenId,
             value,
             baseLayerData,
@@ -165,7 +165,7 @@ contract ERC1155SinglePortalTest is ERC165Test {
 
         // balances before
         assertEq(_token.balanceOf(_alice, tokenId), supply);
-        assertEq(_token.balanceOf(_app, tokenId), 0);
+        assertEq(_token.balanceOf(_appContract, tokenId), 0);
         assertEq(_token.balanceOf(address(_portal), tokenId), 0);
 
         vm.expectCall(address(_inputBox), addInput, 1);
@@ -174,14 +174,14 @@ contract ERC1155SinglePortalTest is ERC165Test {
         emit IERC1155.TransferSingle(
             address(_portal),
             _alice,
-            _app,
+            _appContract,
             tokenId,
             value
         );
 
         _portal.depositSingleERC1155Token(
             _token,
-            _app,
+            _appContract,
             tokenId,
             value,
             baseLayerData,
@@ -191,7 +191,7 @@ contract ERC1155SinglePortalTest is ERC165Test {
 
         // balances after
         assertEq(_token.balanceOf(_alice, tokenId), supply - value);
-        assertEq(_token.balanceOf(_app, tokenId), value);
+        assertEq(_token.balanceOf(_appContract, tokenId), value);
         assertEq(_token.balanceOf(address(_portal), tokenId), 0);
     }
 
@@ -215,7 +215,7 @@ contract ERC1155SinglePortalTest is ERC165Test {
     function _encodeAddInput(
         bytes memory payload
     ) internal view returns (bytes memory) {
-        return abi.encodeCall(IInputBox.addInput, (_app, payload));
+        return abi.encodeCall(IInputBox.addInput, (_appContract, payload));
     }
 
     function _encodeSafeTransferFrom(
@@ -226,7 +226,7 @@ contract ERC1155SinglePortalTest is ERC165Test {
         return
             abi.encodeCall(
                 IERC1155.safeTransferFrom,
-                (_alice, _app, tokenId, value, baseLayerData)
+                (_alice, _appContract, tokenId, value, baseLayerData)
             );
     }
 }

--- a/test/foundry/portals/ERC20Portal.t.sol
+++ b/test/foundry/portals/ERC20Portal.t.sol
@@ -25,14 +25,14 @@ contract NormalToken is ERC20 {
 
 contract ERC20PortalTest is ERC165Test {
     address _alice;
-    address _app;
+    address _appContract;
     IInputBox _inputBox;
     IERC20 _token;
     IERC20Portal _portal;
 
     function setUp() public {
         _alice = vm.addr(1);
-        _app = vm.addr(2);
+        _appContract = vm.addr(2);
         _inputBox = IInputBox(vm.addr(3));
         _token = IERC20(vm.addr(4));
         _portal = new ERC20Portal(_inputBox);
@@ -74,7 +74,7 @@ contract ERC20PortalTest is ERC165Test {
         vm.expectCall(address(_inputBox), addInput, 1);
 
         vm.prank(_alice);
-        _portal.depositERC20Tokens(_token, _app, amount, data);
+        _portal.depositERC20Tokens(_token, _appContract, amount, data);
     }
 
     function testTokenReturnsFalse(uint256 amount, bytes calldata data) public {
@@ -91,7 +91,7 @@ contract ERC20PortalTest is ERC165Test {
         vm.expectRevert(IERC20Portal.ERC20TransferFailed.selector);
 
         vm.prank(_alice);
-        _portal.depositERC20Tokens(_token, _app, amount, data);
+        _portal.depositERC20Tokens(_token, _appContract, amount, data);
     }
 
     function testTokenReverts(
@@ -112,7 +112,7 @@ contract ERC20PortalTest is ERC165Test {
         vm.expectRevert(errorData);
 
         vm.prank(_alice);
-        _portal.depositERC20Tokens(_token, _app, amount, data);
+        _portal.depositERC20Tokens(_token, _appContract, amount, data);
     }
 
     function testNormalToken(
@@ -136,22 +136,22 @@ contract ERC20PortalTest is ERC165Test {
 
         // balances before
         assertEq(token.balanceOf(_alice), supply);
-        assertEq(token.balanceOf(_app), 0);
+        assertEq(token.balanceOf(_appContract), 0);
         assertEq(token.balanceOf(address(_portal)), 0);
 
         vm.expectCall(address(_inputBox), addInput, 1);
 
         vm.expectEmit(true, true, false, true, address(token));
-        emit IERC20.Transfer(_alice, _app, amount);
+        emit IERC20.Transfer(_alice, _appContract, amount);
 
         // deposit tokens
-        _portal.depositERC20Tokens(token, _app, amount, data);
+        _portal.depositERC20Tokens(token, _appContract, amount, data);
 
         vm.stopPrank();
 
         // balances after
         assertEq(token.balanceOf(_alice), supply - amount);
-        assertEq(token.balanceOf(_app), amount);
+        assertEq(token.balanceOf(_appContract), amount);
         assertEq(token.balanceOf(address(_portal)), 0);
     }
 
@@ -166,12 +166,13 @@ contract ERC20PortalTest is ERC165Test {
     function _encodeTransferFrom(
         uint256 amount
     ) internal view returns (bytes memory) {
-        return abi.encodeCall(IERC20.transferFrom, (_alice, _app, amount));
+        return
+            abi.encodeCall(IERC20.transferFrom, (_alice, _appContract, amount));
     }
 
     function _encodeAddInput(
         bytes memory payload
     ) internal view returns (bytes memory) {
-        return abi.encodeCall(IInputBox.addInput, (_app, payload));
+        return abi.encodeCall(IInputBox.addInput, (_appContract, payload));
     }
 }

--- a/test/foundry/portals/ERC721Portal.t.sol
+++ b/test/foundry/portals/ERC721Portal.t.sol
@@ -25,14 +25,14 @@ contract NormalToken is ERC721 {
 
 contract ERC721PortalTest is ERC165Test {
     address _alice;
-    address _app;
+    address _appContract;
     IERC721 _token;
     IInputBox _inputBox;
     IERC721Portal _portal;
 
     function setUp() public {
         _alice = vm.addr(1);
-        _app = vm.addr(2);
+        _appContract = vm.addr(2);
         _token = IERC721(vm.addr(3));
         _inputBox = IInputBox(vm.addr(4));
         _portal = new ERC721Portal(_inputBox);
@@ -86,7 +86,7 @@ contract ERC721PortalTest is ERC165Test {
         vm.prank(_alice);
         _portal.depositERC721Token(
             _token,
-            _app,
+            _appContract,
             tokenId,
             baseLayerData,
             execLayerData
@@ -123,7 +123,7 @@ contract ERC721PortalTest is ERC165Test {
         vm.prank(_alice);
         _portal.depositERC721Token(
             _token,
-            _app,
+            _appContract,
             tokenId,
             baseLayerData,
             execLayerData
@@ -158,11 +158,11 @@ contract ERC721PortalTest is ERC165Test {
         vm.expectCall(address(_inputBox), addInput, 1);
 
         vm.expectEmit(true, true, true, false, address(token));
-        emit IERC721.Transfer(_alice, _app, tokenId);
+        emit IERC721.Transfer(_alice, _appContract, tokenId);
 
         _portal.depositERC721Token(
             token,
-            _app,
+            _appContract,
             tokenId,
             baseLayerData,
             execLayerData
@@ -171,7 +171,7 @@ contract ERC721PortalTest is ERC165Test {
         vm.stopPrank();
 
         // token owner after
-        assertEq(token.ownerOf(tokenId), _app);
+        assertEq(token.ownerOf(tokenId), _appContract);
     }
 
     function _encodePayload(
@@ -193,7 +193,7 @@ contract ERC721PortalTest is ERC165Test {
     function _encodeAddInput(
         bytes memory payload
     ) internal view returns (bytes memory) {
-        return abi.encodeCall(IInputBox.addInput, (_app, payload));
+        return abi.encodeCall(IInputBox.addInput, (_appContract, payload));
     }
 
     function _encodeSafeTransferFrom(
@@ -204,7 +204,7 @@ contract ERC721PortalTest is ERC165Test {
             abi.encodeWithSignature(
                 "safeTransferFrom(address,address,uint256,bytes)",
                 _alice,
-                _app,
+                _appContract,
                 tokenId,
                 baseLayerData
             );

--- a/test/foundry/portals/EtherPortal.t.sol
+++ b/test/foundry/portals/EtherPortal.t.sol
@@ -15,13 +15,13 @@ import {ERC165Test} from "../util/ERC165Test.sol";
 
 contract EtherPortalTest is ERC165Test {
     address _alice;
-    address _app;
+    address _appContract;
     IInputBox _inputBox;
     IEtherPortal _portal;
 
     function setUp() public {
         _alice = vm.addr(1);
-        _app = vm.addr(2);
+        _appContract = vm.addr(2);
         _inputBox = IInputBox(vm.addr(3));
         _portal = new EtherPortal(_inputBox);
     }
@@ -55,17 +55,17 @@ contract EtherPortalTest is ERC165Test {
 
         vm.mockCall(address(_inputBox), addInput, abi.encode(bytes32(0)));
 
-        vm.expectCall(_app, value, abi.encode(), 1);
+        vm.expectCall(_appContract, value, abi.encode(), 1);
 
         vm.expectCall(address(_inputBox), addInput, 1);
 
-        uint256 balance = _app.balance;
+        uint256 balance = _appContract.balance;
 
         vm.deal(_alice, value);
         vm.prank(_alice);
-        _portal.depositEther{value: value}(_app, data);
+        _portal.depositEther{value: value}(_appContract, data);
 
-        assertEq(_app.balance, balance + value);
+        assertEq(_appContract.balance, balance + value);
     }
 
     function testDepositReverts(
@@ -75,7 +75,7 @@ contract EtherPortalTest is ERC165Test {
     ) public {
         value = _boundValue(value);
 
-        vm.mockCallRevert(_app, value, abi.encode(), errorData);
+        vm.mockCallRevert(_appContract, value, abi.encode(), errorData);
 
         bytes memory payload = _encodePayload(value, data);
 
@@ -87,7 +87,7 @@ contract EtherPortalTest is ERC165Test {
 
         vm.deal(_alice, value);
         vm.prank(_alice);
-        _portal.depositEther{value: value}(_app, data);
+        _portal.depositEther{value: value}(_appContract, data);
     }
 
     function _encodePayload(
@@ -100,7 +100,7 @@ contract EtherPortalTest is ERC165Test {
     function _encodeAddInput(
         bytes memory payload
     ) internal view returns (bytes memory) {
-        return abi.encodeCall(IInputBox.addInput, (_app, payload));
+        return abi.encodeCall(IInputBox.addInput, (_appContract, payload));
     }
 
     function _boundValue(uint256 value) internal view returns (uint256) {

--- a/test/foundry/util/EvmAdvanceEncoder.sol
+++ b/test/foundry/util/EvmAdvanceEncoder.sol
@@ -9,7 +9,7 @@ import {Inputs} from "contracts/common/Inputs.sol";
 library EvmAdvanceEncoder {
     function encode(
         uint256 chainId,
-        address app,
+        address appContract,
         address sender,
         uint256 index,
         bytes memory payload
@@ -19,7 +19,7 @@ library EvmAdvanceEncoder {
                 Inputs.EvmAdvance,
                 (
                     chainId,
-                    app,
+                    appContract,
                     sender,
                     block.number,
                     block.timestamp,


### PR DESCRIPTION
* Renamed `app` -> `appContract` in `Inputs`
* Renamed `sender` -> `msgSender` in `Inputs`
* Removed `EvmInspect` from `Inputs`
* Adjust the rest of the contracts to the new nomenclature