### PR TITLE
feat: add `block.prevrandao` to input metadata

### DIFF
--- a/contracts/common/Inputs.sol
+++ b/contracts/common/Inputs.sol
@@ -12,14 +12,17 @@ interface Inputs {
     /// @param msgSender The address of whoever sent the input
     /// @param blockNumber The number of the block in which the input was added
     /// @param blockTimestamp The timestamp of the block in which the input was added
+    /// @param prevRandao The latest RANDAO mix of the post beacon state of the previous block
     /// @param index The index of the input in the input box
     /// @param payload The payload provided by the message sender
+    /// @dev See EIP-4399 for safe usage of `prevRandao`.
     function EvmAdvance(
         uint256 chainId,
         address appContract,
         address msgSender,
         uint256 blockNumber,
         uint256 blockTimestamp,
+        uint256 prevRandao,
         uint256 index,
         bytes calldata payload
     ) external;

--- a/contracts/inputs/InputBox.sol
+++ b/contracts/inputs/InputBox.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.18;
 
 import {IInputBox} from "./IInputBox.sol";
 import {CanonicalMachine} from "../common/CanonicalMachine.sol";
@@ -28,6 +28,7 @@ contract InputBox is IInputBox {
                 msg.sender,
                 block.number,
                 block.timestamp,
+                block.prevrandao,
                 index,
                 payload
             )

--- a/test/foundry/inputs/InputBox.t.sol
+++ b/test/foundry/inputs/InputBox.t.sol
@@ -64,6 +64,7 @@ contract InputBoxTest is Test {
             // test for different block number and timestamp
             vm.roll(i);
             vm.warp(i + year2022);
+            vm.prevrandao(bytes32(_prevrandao(i)));
 
             vm.expectEmit(true, true, false, true, address(_inputBox));
             bytes memory input = EvmAdvanceEncoder.encode(
@@ -91,6 +92,7 @@ contract InputBoxTest is Test {
                         address(this),
                         i, // block.number
                         i + year2022, // block.timestamp
+                        _prevrandao(i), // block.prevrandao
                         i, // inputBox.length
                         payloads[i]
                     )
@@ -103,10 +105,14 @@ contract InputBoxTest is Test {
         }
     }
 
+    function _prevrandao(uint256 blockNumber) internal pure returns (uint256) {
+        return uint256(keccak256(abi.encode("prevrandao", blockNumber)));
+    }
+
     function _getMaxInputPayloadLength() internal pure returns (uint256) {
         bytes memory blob = abi.encodeCall(
             Inputs.EvmAdvance,
-            (0, address(0), address(0), 0, 0, 0, new bytes(32))
+            (0, address(0), address(0), 0, 0, 0, 0, new bytes(32))
         );
         // number of bytes in input blob excluding input payload
         uint256 extraBytes = blob.length - 32;

--- a/test/foundry/util/EvmAdvanceEncoder.sol
+++ b/test/foundry/util/EvmAdvanceEncoder.sol
@@ -23,6 +23,7 @@ library EvmAdvanceEncoder {
                     sender,
                     block.number,
                     block.timestamp,
+                    block.prevrandao,
                     index,
                     payload
                 )


### PR DESCRIPTION
Closes #256 
