### PR TITLE
refactor: remove `pnpm test` script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: ./.github/workflows/setup
 
       - name: Run tests
-        run: pnpm test
+        run: forge test -vvv
 
       - name: Upload signatures
         run: forge selectors upload --all

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,5 @@
-.DS_Store
-.env
-.node*
-.vscode
-/abi
 /artifacts
 /cache
-/contracts.json
 /coverage*
 /deployments/*/solcInputs/*.json
 /deployments/localhost

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,11 +3,7 @@ cache
 deployments
 dist
 export
-generated-src
 src/types
-abi
 out
 lib
 forge-cache
-test/foundry/dapp/helper/input
-test/foundry/dapp/helper/output

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If the node is not listening to `http://localhost:8545/`, please set the `RPC_UR
 If you want to run the tests, please run the following command.
 
 ```sh
-pnpm test
+forge test -vvv
 ```
 
 ## 📚 Documentation

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
         "preinstall": "npx only-allow pnpm",
         "prepack": "run-s build tsc:prod copy-dts",
         "start": "hardhat node",
-        "test": "forge test -vvv",
         "tsc": "tsc",
         "tsc:prod": "tsc -p tsconfig.prod.json"
     },

--- a/test/foundry/dapp/Application.t.sol
+++ b/test/foundry/dapp/Application.t.sol
@@ -421,7 +421,7 @@ contract ApplicationTest is ERC165Test {
             _tokenIds.push(i);
             _initialSupplies.push(_initialSupply);
             _transferAmounts.push(
-                bound(uint256(keccak256(abi.encode(i))), 1, _initialSupply)
+                1 + (uint256(keccak256(abi.encode(i))) % _initialSupply)
             );
         }
     }


### PR DESCRIPTION
Also removes several legacy lines in `.gitignore` and `.prettierignore`.

Closes #280 