### PR TITLE
ci: fix contract artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,34 +44,6 @@ jobs:
         id: get_version
         run: jq -r '"version=\(.version)"' package.json >> "$GITHUB_OUTPUT"
 
-  upload_contract_artifacts_to_gh_releases:
-    name: Upload contract artifacts to GitHub Releases
-    needs: version_or_publish
-    if: ${{ needs.version_or_publish.outputs.published == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - uses: ./.github/workflows/setup
-
-      - name: Build contracts
-        run: pnpm build
-
-      - name: Create upload folder
-        run: mkdir -p upload
-
-      - name: Compress contract artifacts
-        run: tar -czf "$FILEPATH" -C export/artifacts/contracts .
-        env:
-          FILEPATH: upload/rollups-contracts-${{ needs.version_or_publish.outputs.version }}-artifacts.tar.gz
-
-      - name: Upload files to GitHub Releases
-        uses: softprops/action-gh-release@v2
-        with:
-          files: upload/*
-
   rust_bindings:
     name: Generate and publish Rust bindings
     needs: version_or_publish

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -1,0 +1,38 @@
+name: Upload artifacts
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  upload:
+    name: Upload contract artifacts to GitHub Releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/workflows/setup
+
+      - name: Build contracts
+        run: pnpm build
+
+      - name: Create upload folder
+        run: mkdir -p upload
+
+      - name: Extract version from tag
+        id: extract_version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Compress contract artifacts
+        run: tar -czf "$FILEPATH" -C export/artifacts/contracts .
+        env:
+          FILEPATH: upload/rollups-contracts-${{ steps.extract_version.outputs.version }}-artifacts.tar.gz
+
+      - name: Upload files to GitHub Releases
+        uses: softprops/action-gh-release@v2
+        with:
+          files: upload/*
+


### PR DESCRIPTION
Apparently, the `softprops/action-gh-release` action needs to be run on a workflow triggered by a push to a version tag.