### PR TITLE
chore: revert "use default output directory"

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,6 @@
 [profile.default]
 src = 'contracts'
+out = 'out'
 libs = ['node_modules', 'lib']
 solc_version = '0.8.23'
 


### PR DESCRIPTION
This reverts commit 086e7755b63dea44325561eecf831896f7b29d9e.

According to Foundry documentation, the default value of the `out` dir is `out`, but, in actuality, it is `artifacts`...
I've opened a PR to fix their docs (https://github.com/foundry-rs/book/pull/1337)