### PR TITLE
feat: add `InsufficientFunds` error

### DIFF
--- a/contracts/library/LibAddress.sol
+++ b/contracts/library/LibAddress.sol
@@ -8,16 +8,31 @@ import {LibError} from "../library/LibError.sol";
 library LibAddress {
     using LibError for bytes;
 
+    /// @notice Caller does not have enough Ether to make call
+    /// @param caller The address of the contract making the call
+    /// @param value The value being transmitted through the call
+    /// @param balance The current contract balance
+    error InsufficientFunds(address caller, uint256 value, uint256 balance);
+
     /// @notice Perform a low level call and raise error if failed
     /// @param destination The address that will be called
     /// @param value The amount of Wei to be transferred through the call
     /// @param payload The payload, which—in the case of Solidity
     /// contracts—encodes a function call
+    /// @dev Raises an `InsufficientFunds` error
+    /// if the caller has less than `value` Wei
     function safeCall(
         address destination,
         uint256 value,
         bytes memory payload
     ) internal {
+        address caller = address(this);
+        uint256 balance = caller.balance;
+
+        if (value > balance) {
+            revert InsufficientFunds(caller, value, balance);
+        }
+
         bool success;
         bytes memory returndata;
 

--- a/test/dapp/Application.t.sol
+++ b/test/dapp/Application.t.sol
@@ -13,6 +13,7 @@ import {OutputValidityProof} from "contracts/common/OutputValidityProof.sol";
 import {Outputs} from "contracts/common/Outputs.sol";
 import {SafeERC20Transfer} from "contracts/delegatecall/SafeERC20Transfer.sol";
 import {IOwnable} from "contracts/access/IOwnable.sol";
+import {LibAddress} from "contracts/library/LibAddress.sol";
 
 import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
@@ -559,7 +560,14 @@ contract ApplicationTest is TestBase, OwnableTest {
             "Application contract does not have enough Ether"
         );
 
-        vm.expectRevert();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibAddress.InsufficientFunds.selector,
+                address(_appContract),
+                _transferAmount,
+                0
+            )
+        );
         _appContract.executeOutput(output, proof);
 
         vm.deal(address(_appContract), _transferAmount);


### PR DESCRIPTION
As of now, trying to execute a voucher that transfers more value than the contract balance reverts with an empty return byte array. This can be very hard to debug. We can anticipate this error and raise a nicely formatted custom error instead.