### PR TITLE
refactor: split `IConsensus` interface into two

### DIFF
--- a/contracts/consensus/AbstractClaimSubmitter.sol
+++ b/contracts/consensus/AbstractClaimSubmitter.sol
@@ -17,7 +17,8 @@ abstract contract AbstractClaimSubmitter is IClaimSubmitter, ERC165 {
     uint256 private immutable _epochLength;
 
     /// @notice Indexes accepted claims by application contract address.
-    mapping(address => mapping(bytes32 => bool)) private _acceptedClaims;
+    mapping(address => mapping(bytes32 => bool))
+        private _validOutputsMerkleRoots;
 
     /// @param epochLength The epoch length
     /// @dev Reverts if the epoch length is zero.
@@ -27,11 +28,11 @@ abstract contract AbstractClaimSubmitter is IClaimSubmitter, ERC165 {
     }
 
     /// @inheritdoc IConsensus
-    function wasClaimAccepted(
+    function isOutputsMerkleRootValid(
         address appContract,
-        bytes32 claim
+        bytes32 outputsMerkleRoot
     ) public view override returns (bool) {
-        return _acceptedClaims[appContract][claim];
+        return _validOutputsMerkleRoots[appContract][outputsMerkleRoot];
     }
 
     /// @inheritdoc IClaimSubmitter
@@ -51,14 +52,18 @@ abstract contract AbstractClaimSubmitter is IClaimSubmitter, ERC165 {
     /// @notice Accept a claim.
     /// @param appContract The application contract address
     /// @param lastProcessedBlockNumber The number of the last processed block
-    /// @param claim The output Merkle root hash
+    /// @param outputsMerkleRoot The output Merkle root hash
     /// @dev Emits a `ClaimAcceptance` event.
     function _acceptClaim(
         address appContract,
         uint256 lastProcessedBlockNumber,
-        bytes32 claim
+        bytes32 outputsMerkleRoot
     ) internal {
-        _acceptedClaims[appContract][claim] = true;
-        emit ClaimAcceptance(appContract, lastProcessedBlockNumber, claim);
+        _validOutputsMerkleRoots[appContract][outputsMerkleRoot] = true;
+        emit ClaimAcceptance(
+            appContract,
+            lastProcessedBlockNumber,
+            outputsMerkleRoot
+        );
     }
 }

--- a/contracts/consensus/AbstractClaimSubmitter.sol
+++ b/contracts/consensus/AbstractClaimSubmitter.sol
@@ -3,12 +3,16 @@
 
 pragma solidity ^0.8.8;
 
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
 import {IConsensus} from "./IConsensus.sol";
+import {IClaimSubmitter} from "./IClaimSubmitter.sol";
 
 /// @notice Stores accepted claims for several applications.
-/// @dev This contract was designed to be inherited by implementations of the `IConsensus` interface
+/// @dev This contract was designed to be inherited by implementations of the `IClaimSubmitter` interface
 /// that only need a simple mechanism of storage and retrieval of accepted claims.
-abstract contract AbstractConsensus is IConsensus {
+abstract contract AbstractClaimSubmitter is IClaimSubmitter, ERC165 {
     /// @notice The epoch length
     uint256 private immutable _epochLength;
 
@@ -30,9 +34,18 @@ abstract contract AbstractConsensus is IConsensus {
         return _acceptedClaims[appContract][claim];
     }
 
-    /// @inheritdoc IConsensus
+    /// @inheritdoc IClaimSubmitter
     function getEpochLength() public view override returns (uint256) {
         return _epochLength;
+    }
+
+    /// @inheritdoc ERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(IERC165, ERC165) returns (bool) {
+        return
+            interfaceId == type(IClaimSubmitter).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     /// @notice Accept a claim.

--- a/contracts/consensus/AbstractClaimSubmitter.sol
+++ b/contracts/consensus/AbstractClaimSubmitter.sol
@@ -9,9 +9,7 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IConsensus} from "./IConsensus.sol";
 import {IClaimSubmitter} from "./IClaimSubmitter.sol";
 
-/// @notice Stores accepted claims for several applications.
-/// @dev This contract was designed to be inherited by implementations of the `IClaimSubmitter` interface
-/// that only need a simple mechanism of storage and retrieval of accepted claims.
+/// @notice Abstract implementation of IClaimSubmitter
 abstract contract AbstractClaimSubmitter is IClaimSubmitter, ERC165 {
     /// @notice The epoch length
     uint256 private immutable _epochLength;

--- a/contracts/consensus/IClaimSubmitter.sol
+++ b/contracts/consensus/IClaimSubmitter.sol
@@ -1,0 +1,63 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+pragma solidity ^0.8.8;
+
+import {IConsensus} from "./IConsensus.sol";
+
+/// @notice Each application has its own stream of inputs.
+/// See the `IInputBox` interface for calldata-based on-chain data availability.
+/// @notice When an input is fed to the application, it may yield several outputs.
+/// @notice Since genesis, a Merkle tree of all outputs ever produced is maintained
+/// both inside and outside the Cartesi Machine.
+/// @notice The claim that validators may submit to the consensus contract
+/// is the root of this Merkle tree after processing all base layer blocks until some height.
+/// @notice A validator should be able to save transaction fees by not submitting a claim if it was...
+/// - already submitted by the validator (see the `ClaimSubmission` event) or;
+/// - already accepted by the consensus (see the `ClaimAcceptance` event).
+/// @notice The acceptance criteria for claims may depend on the type of consensus, and is not specified by this interface.
+/// For example, a claim may be accepted if it was...
+/// - submitted by an authority or;
+/// - submitted by the majority of a quorum or;
+/// - submitted and not proven wrong after some period of time or;
+/// - submitted and proven correct through an on-chain tournament.
+interface IClaimSubmitter is IConsensus {
+    /// @notice MUST trigger when a claim is submitted.
+    /// @param submitter The submitter address
+    /// @param appContract The application contract address
+    /// @param lastProcessedBlockNumber The number of the last processed block
+    /// @param outputsMerkleRoot The outputs Merkle root
+    event ClaimSubmission(
+        address indexed submitter,
+        address indexed appContract,
+        uint256 lastProcessedBlockNumber,
+        bytes32 outputsMerkleRoot
+    );
+
+    /// @notice MUST trigger when a claim is accepted.
+    /// @param appContract The application contract address
+    /// @param lastProcessedBlockNumber The number of the last processed block
+    /// @param outputsMerkleRoot The outputs Merkle root
+    event ClaimAcceptance(
+        address indexed appContract,
+        uint256 lastProcessedBlockNumber,
+        bytes32 outputsMerkleRoot
+    );
+
+    /// @notice Submit a claim to the consensus.
+    /// @param appContract The application contract address
+    /// @param lastProcessedBlockNumber The number of the last processed block
+    /// @param outputsMerkleRoot The outputs Merkle root
+    /// @dev MUST fire a `ClaimSubmission` event.
+    /// @dev MAY fire a `ClaimAcceptance` event, if the acceptance criteria is met.
+    function submitClaim(
+        address appContract,
+        uint256 lastProcessedBlockNumber,
+        bytes32 outputsMerkleRoot
+    ) external;
+
+    /// @notice Get the epoch length, in number of base layer blocks.
+    /// @dev The epoch number of a block is defined as
+    /// the integer division of the block number by the epoch length.
+    function getEpochLength() external view returns (uint256);
+}

--- a/contracts/consensus/IConsensus.sol
+++ b/contracts/consensus/IConsensus.sol
@@ -3,57 +3,14 @@
 
 pragma solidity ^0.8.8;
 
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
 /// @notice Each application has its own stream of inputs.
 /// See the `IInputBox` interface for calldata-based on-chain data availability.
 /// @notice When an input is fed to the application, it may yield several outputs.
 /// @notice Since genesis, a Merkle tree of all outputs ever produced is maintained
 /// both inside and outside the Cartesi Machine.
-/// @notice The claim that validators may submit to the consensus contract
-/// is the root of this Merkle tree after processing all base layer blocks until some height.
-/// @notice A validator should be able to save transaction fees by not submitting a claim if it was...
-/// - already submitted by the validator (see the `ClaimSubmission` event) or;
-/// - already accepted by the consensus (see the `ClaimAcceptance` event).
-/// @notice The acceptance criteria for claims may depend on the type of consensus, and is not specified by this interface.
-/// For example, a claim may be accepted if it was...
-/// - submitted by an authority or;
-/// - submitted by the majority of a quorum or;
-/// - submitted and not proven wrong after some period of time or;
-/// - submitted and proven correct through an on-chain tournament.
-interface IConsensus {
-    /// @notice MUST trigger when a claim is submitted.
-    /// @param submitter The submitter address
-    /// @param appContract The application contract address
-    /// @param lastProcessedBlockNumber The number of the last processed block
-    /// @param claim The root of the Merkle tree of outputs
-    event ClaimSubmission(
-        address indexed submitter,
-        address indexed appContract,
-        uint256 lastProcessedBlockNumber,
-        bytes32 claim
-    );
-
-    /// @notice MUST trigger when a claim is accepted.
-    /// @param appContract The application contract address
-    /// @param lastProcessedBlockNumber The number of the last processed block
-    /// @param claim The root of the Merkle tree of outputs
-    event ClaimAcceptance(
-        address indexed appContract,
-        uint256 lastProcessedBlockNumber,
-        bytes32 claim
-    );
-
-    /// @notice Submit a claim to the consensus.
-    /// @param appContract The application contract address
-    /// @param lastProcessedBlockNumber The number of the last processed block
-    /// @param claim The root of the Merkle tree of outputs
-    /// @dev MUST fire a `ClaimSubmission` event.
-    /// @dev MAY fire a `ClaimAcceptance` event, if the acceptance criteria is met.
-    function submitClaim(
-        address appContract,
-        uint256 lastProcessedBlockNumber,
-        bytes32 claim
-    ) external;
-
+interface IConsensus is IERC165 {
     /// @notice Check if an output Merkle root hash was ever accepted by the consensus
     /// for a particular application.
     /// @param appContract The application contract address
@@ -62,9 +19,4 @@ interface IConsensus {
         address appContract,
         bytes32 claim
     ) external view returns (bool);
-
-    /// @notice Get the epoch length, in number of base layer blocks.
-    /// @dev The epoch number of a block is defined as
-    /// the integer division of the block number by the epoch length.
-    function getEpochLength() external view returns (uint256);
 }

--- a/contracts/consensus/IConsensus.sol
+++ b/contracts/consensus/IConsensus.sol
@@ -11,12 +11,11 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 /// @notice Since genesis, a Merkle tree of all outputs ever produced is maintained
 /// both inside and outside the Cartesi Machine.
 interface IConsensus is IERC165 {
-    /// @notice Check if an output Merkle root hash was ever accepted by the consensus
-    /// for a particular application.
+    /// @notice Check whether an outputs Merkle root is valid.
     /// @param appContract The application contract address
-    /// @param claim The root of the Merkle tree of outputs
-    function wasClaimAccepted(
+    /// @param outputsMerkleRoot The outputs Merkle root
+    function isOutputsMerkleRootValid(
         address appContract,
-        bytes32 claim
+        bytes32 outputsMerkleRoot
     ) external view returns (bool);
 }

--- a/contracts/consensus/IConsensus.sol
+++ b/contracts/consensus/IConsensus.sol
@@ -5,11 +5,9 @@ pragma solidity ^0.8.8;
 
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
-/// @notice Each application has its own stream of inputs.
-/// See the `IInputBox` interface for calldata-based on-chain data availability.
-/// @notice When an input is fed to the application, it may yield several outputs.
-/// @notice Since genesis, a Merkle tree of all outputs ever produced is maintained
-/// both inside and outside the Cartesi Machine.
+/// @notice Provides valid outputs Merkle roots for validation.
+/// @dev ERC-165 can be used to determine whether this contract also
+/// supports any other interface (e.g. for submitting claims).
 interface IConsensus is IERC165 {
     /// @notice Check whether an outputs Merkle root is valid.
     /// @param appContract The application contract address

--- a/contracts/consensus/authority/Authority.sol
+++ b/contracts/consensus/authority/Authority.sol
@@ -38,14 +38,17 @@ contract Authority is IAuthority, AbstractClaimSubmitter, Ownable {
         _acceptClaim(appContract, lastProcessedBlockNumber, outputsMerkleRoot);
     }
 
+    /// @inheritdoc Ownable
     function owner() public view override(IOwnable, Ownable) returns (address) {
         return super.owner();
     }
 
+    /// @inheritdoc Ownable
     function renounceOwnership() public override(IOwnable, Ownable) {
         super.renounceOwnership();
     }
 
+    /// @inheritdoc Ownable
     function transferOwnership(
         address newOwner
     ) public override(IOwnable, Ownable) {

--- a/contracts/consensus/authority/Authority.sol
+++ b/contracts/consensus/authority/Authority.sol
@@ -3,24 +3,25 @@
 
 pragma solidity ^0.8.8;
 
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 import {IAuthority} from "./IAuthority.sol";
-import {IConsensus} from "../IConsensus.sol";
-import {AbstractConsensus} from "../AbstractConsensus.sol";
+import {IClaimSubmitter} from "../IClaimSubmitter.sol";
+import {AbstractClaimSubmitter} from "../AbstractClaimSubmitter.sol";
 import {IOwnable} from "../../access/IOwnable.sol";
 
 /// @notice A consensus contract controlled by a single address, the owner.
 /// @dev This contract inherits from OpenZeppelin's `Ownable` contract.
 ///      For more information on `Ownable`, please consult OpenZeppelin's official documentation.
-contract Authority is IAuthority, AbstractConsensus, Ownable {
+contract Authority is IAuthority, AbstractClaimSubmitter, Ownable {
     /// @param initialOwner The initial contract owner
     /// @param epochLength The epoch length
     /// @dev Reverts if the epoch length is zero.
     constructor(
         address initialOwner,
         uint256 epochLength
-    ) AbstractConsensus(epochLength) Ownable(initialOwner) {}
+    ) AbstractClaimSubmitter(epochLength) Ownable(initialOwner) {}
 
     /// @notice Submit a claim.
     /// @param appContract The application contract address
@@ -54,5 +55,14 @@ contract Authority is IAuthority, AbstractConsensus, Ownable {
         address newOwner
     ) public override(IOwnable, Ownable) {
         super.transferOwnership(newOwner);
+    }
+
+    /// @inheritdoc AbstractClaimSubmitter
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view override(IERC165, AbstractClaimSubmitter) returns (bool) {
+        return
+            interfaceId == type(IAuthority).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/consensus/authority/Authority.sol
+++ b/contracts/consensus/authority/Authority.sol
@@ -23,24 +23,19 @@ contract Authority is IAuthority, AbstractClaimSubmitter, Ownable {
         uint256 epochLength
     ) AbstractClaimSubmitter(epochLength) Ownable(initialOwner) {}
 
-    /// @notice Submit a claim.
-    /// @param appContract The application contract address
-    /// @param lastProcessedBlockNumber The number of the last processed block
-    /// @param claim The output Merkle root hash
-    /// @dev Fires a `ClaimSubmission` event and a `ClaimAcceptance` event.
-    /// @dev Can only be called by the owner.
+    /// @inheritdoc IClaimSubmitter
     function submitClaim(
         address appContract,
         uint256 lastProcessedBlockNumber,
-        bytes32 claim
+        bytes32 outputsMerkleRoot
     ) external override onlyOwner {
         emit ClaimSubmission(
             msg.sender,
             appContract,
             lastProcessedBlockNumber,
-            claim
+            outputsMerkleRoot
         );
-        _acceptClaim(appContract, lastProcessedBlockNumber, claim);
+        _acceptClaim(appContract, lastProcessedBlockNumber, outputsMerkleRoot);
     }
 
     function owner() public view override(IOwnable, Ownable) returns (address) {

--- a/contracts/consensus/authority/IAuthority.sol
+++ b/contracts/consensus/authority/IAuthority.sol
@@ -4,7 +4,7 @@
 pragma solidity ^0.8.8;
 
 import {IOwnable} from "../../access/IOwnable.sol";
-import {IConsensus} from "../IConsensus.sol";
+import {IClaimSubmitter} from "../IClaimSubmitter.sol";
 
 /// @notice A consensus contract controlled by a single address, the owner.
-interface IAuthority is IConsensus, IOwnable {}
+interface IAuthority is IClaimSubmitter, IOwnable {}

--- a/contracts/consensus/quorum/IQuorum.sol
+++ b/contracts/consensus/quorum/IQuorum.sol
@@ -30,25 +30,25 @@ interface IQuorum is IClaimSubmitter {
     /// @notice Get the number of validators in favor of a claim.
     /// @param appContract The application contract address
     /// @param lastProcessedBlockNumber The number of the last processed block
-    /// @param claim The output Merkle root hash
+    /// @param outputsMerkleRoot The outputs Merkle root
     /// @return Number of validators in favor of claim
     function numOfValidatorsInFavorOf(
         address appContract,
         uint256 lastProcessedBlockNumber,
-        bytes32 claim
+        bytes32 outputsMerkleRoot
     ) external view returns (uint256);
 
     /// @notice Check whether a validator is in favor of a claim.
     /// @param appContract The application contract address
     /// @param lastProcessedBlockNumber The number of the last processed block
-    /// @param claim The output Merkle root hash
+    /// @param outputsMerkleRoot The outputs Merkle root
     /// @param id The ID of the validator
     /// @return Whether validator is in favor of claim
     /// @dev Assumes the provided ID is valid.
     function isValidatorInFavorOf(
         address appContract,
         uint256 lastProcessedBlockNumber,
-        bytes32 claim,
+        bytes32 outputsMerkleRoot,
         uint256 id
     ) external view returns (bool);
 }

--- a/contracts/consensus/quorum/IQuorum.sol
+++ b/contracts/consensus/quorum/IQuorum.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.8;
 
-import {IConsensus} from "../IConsensus.sol";
+import {IClaimSubmitter} from "../IClaimSubmitter.sol";
 
 /// @notice A consensus model controlled by a small, immutable set of `n` validators.
 /// @notice You can know the value of `n` by calling the `numOfValidators` function.
@@ -11,7 +11,7 @@ import {IConsensus} from "../IConsensus.sol";
 /// These numbers are used internally instead of addresses for gas optimization reasons.
 /// @notice You can list the validators in the quorum by calling the `validatorById`
 /// function for each ID from 1 to `n`.
-interface IQuorum is IConsensus {
+interface IQuorum is IClaimSubmitter {
     /// @notice Get the number of validators.
     function numOfValidators() external view returns (uint256);
 

--- a/contracts/consensus/quorum/Quorum.sol
+++ b/contracts/consensus/quorum/Quorum.sol
@@ -4,11 +4,12 @@
 pragma solidity ^0.8.8;
 
 import {BitMaps} from "@openzeppelin/contracts/utils/structs/BitMaps.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {IQuorum} from "./IQuorum.sol";
-import {AbstractConsensus} from "../AbstractConsensus.sol";
+import {AbstractClaimSubmitter} from "../AbstractClaimSubmitter.sol";
 
-contract Quorum is IQuorum, AbstractConsensus {
+contract Quorum is IQuorum, AbstractClaimSubmitter {
     using BitMaps for BitMaps.BitMap;
 
     /// @notice The total number of validators.
@@ -48,7 +49,7 @@ contract Quorum is IQuorum, AbstractConsensus {
     constructor(
         address[] memory validators,
         uint256 epochLength
-    ) AbstractConsensus(epochLength) {
+    ) AbstractClaimSubmitter(epochLength) {
         uint256 n;
         for (uint256 i; i < validators.length; ++i) {
             address validator = validators[i];
@@ -139,5 +140,14 @@ contract Quorum is IQuorum, AbstractConsensus {
         bytes32 claim
     ) internal view returns (Votes storage) {
         return _votes[appContract][lastProcessedBlockNumber][claim];
+    }
+
+    /// @inheritdoc AbstractClaimSubmitter
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view override(IERC165, AbstractClaimSubmitter) returns (bool) {
+        return
+            interfaceId == type(IQuorum).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/dapp/Application.sol
+++ b/contracts/dapp/Application.sol
@@ -127,10 +127,10 @@ contract Application is
             revert InvalidOutputHashesSiblingsArrayLength();
         }
 
-        bytes32 claim = proof.computeClaim(outputHash);
+        bytes32 outputsMerkleRoot = proof.computeOutputsMerkleRoot(outputHash);
 
-        if (!_wasClaimAccepted(claim)) {
-            revert ClaimNotAccepted(claim);
+        if (!_isOutputsMerkleRootValid(outputsMerkleRoot)) {
+            revert InvalidOutputsMerkleRoot(outputsMerkleRoot);
         }
     }
 
@@ -165,10 +165,17 @@ contract Application is
         super.transferOwnership(newOwner);
     }
 
-    /// @notice Check if an output Merkle root hash was ever accepted by the current consensus.
-    /// @param claim The output Merkle root hash
-    function _wasClaimAccepted(bytes32 claim) internal view returns (bool) {
-        return _consensus.wasClaimAccepted(address(this), claim);
+    /// @notice Check if an outputs Merkle root is valid,
+    /// according to the current consensus.
+    /// @param outputsMerkleRoot The output Merkle root
+    function _isOutputsMerkleRootValid(
+        bytes32 outputsMerkleRoot
+    ) internal view returns (bool) {
+        return
+            _consensus.isOutputsMerkleRootValid(
+                address(this),
+                outputsMerkleRoot
+            );
     }
 
     /// @notice Executes a voucher

--- a/contracts/dapp/IApplication.sol
+++ b/contracts/dapp/IApplication.sol
@@ -24,7 +24,6 @@ import {OutputValidityProof} from "../common/OutputValidityProof.sol";
 /// - multiple signers (multi-sig)
 /// - DAO (decentralized autonomous organization)
 /// - self-owned application (off-chain governance logic)
-/// @notice See `IConsensus` for examples of consensus models.
 interface IApplication is IOwnable {
     // Events
 

--- a/contracts/dapp/IApplication.sol
+++ b/contracts/dapp/IApplication.sol
@@ -55,8 +55,8 @@ interface IApplication is IOwnable {
     /// @dev Please consult `CanonicalMachine` for the maximum number of outputs.
     error InvalidOutputHashesSiblingsArrayLength();
 
-    /// @notice Raised when the required claim was not accepted by the current consensus.
-    error ClaimNotAccepted(bytes32 claim);
+    /// @notice Raised when the computed outputs Merkle root is invalid, according to the current consensus.
+    error InvalidOutputsMerkleRoot(bytes32 outputsMerkleRoot);
 
     // Permissioned functions
 
@@ -101,7 +101,7 @@ interface IApplication is IOwnable {
     /// @param proof The proof used to validate the output against
     ///              a claim submitted to the current consensus contract
     /// @dev May raise `InvalidOutputHashesSiblingsArrayLength`
-    /// or `ClaimNotAccepted`.
+    /// or `InvalidOutputsMerkleRoot`.
     function validateOutputHash(
         bytes32 outputHash,
         OutputValidityProof calldata proof

--- a/contracts/dapp/IApplication.sol
+++ b/contracts/dapp/IApplication.sol
@@ -70,7 +70,7 @@ interface IApplication is IOwnable {
     /// @notice Execute an output.
     /// @param output The output
     /// @param proof The proof used to validate the output against
-    ///              a claim submitted to the current consensus contract
+    ///              a claim accepted to the current consensus contract
     /// @dev On a successful execution, emits a `OutputExecuted` event.
     /// @dev May raise any of the errors raised by `validateOutput`,
     /// as well as `OutputNotExecutable` and `OutputNotReexecutable`.
@@ -89,7 +89,7 @@ interface IApplication is IOwnable {
     /// @notice Validate an output.
     /// @param output The output
     /// @param proof The proof used to validate the output against
-    ///              a claim submitted to the current consensus contract
+    ///              a claim accepted to the current consensus contract
     /// @dev May raise any of the errors raised by `validateOutputHash`.
     function validateOutput(
         bytes calldata output,
@@ -99,7 +99,7 @@ interface IApplication is IOwnable {
     /// @notice Validate an output hash.
     /// @param outputHash The output hash
     /// @param proof The proof used to validate the output against
-    ///              a claim submitted to the current consensus contract
+    ///              a claim accepted to the current consensus contract
     /// @dev May raise `InvalidOutputHashesSiblingsArrayLength`
     /// or `InvalidOutputsMerkleRoot`.
     function validateOutputHash(

--- a/contracts/library/LibOutputValidityProof.sol
+++ b/contracts/library/LibOutputValidityProof.sol
@@ -18,7 +18,7 @@ library LibOutputValidityProof {
             v.outputHashesSiblings.length == CanonicalMachine.LOG2_MAX_OUTPUTS;
     }
 
-    function computeClaim(
+    function computeOutputsMerkleRoot(
         OutputValidityProof calldata v,
         bytes32 outputHash
     ) internal pure returns (bytes32) {

--- a/test/consensus/authority/Authority.t.sol
+++ b/test/consensus/authority/Authority.t.sol
@@ -9,7 +9,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 import {Authority} from "contracts/consensus/authority/Authority.sol";
 import {IAuthority} from "contracts/consensus/authority/IAuthority.sol";
-import {IConsensus} from "contracts/consensus/IConsensus.sol";
+import {IClaimSubmitter} from "contracts/consensus/IClaimSubmitter.sol";
 import {IOwnable} from "contracts/access/IOwnable.sol";
 
 import {TestBase} from "../../util/TestBase.sol";
@@ -154,7 +154,7 @@ contract AuthorityTest is TestBase, OwnableTest {
         bytes32 claim
     ) internal {
         vm.expectEmit(true, true, false, true, address(authority));
-        emit IConsensus.ClaimSubmission(
+        emit IClaimSubmitter.ClaimSubmission(
             owner,
             appContract,
             lastProcessedBlockNumber,
@@ -162,7 +162,7 @@ contract AuthorityTest is TestBase, OwnableTest {
         );
 
         vm.expectEmit(true, false, false, true, address(authority));
-        emit IConsensus.ClaimAcceptance(
+        emit IClaimSubmitter.ClaimAcceptance(
             appContract,
             lastProcessedBlockNumber,
             claim

--- a/test/consensus/authority/Authority.t.sol
+++ b/test/consensus/authority/Authority.t.sol
@@ -129,10 +129,10 @@ contract AuthorityTest is TestBase, OwnableTest {
         vm.prank(owner);
         authority.submitClaim(appContract, lastProcessedBlockNumber, claim);
 
-        assertTrue(authority.wasClaimAccepted(appContract, claim));
+        assertTrue(authority.isOutputsMerkleRootValid(appContract, claim));
     }
 
-    function testWasClaimAccepted(
+    function testIsOutputsMerkleRootValid(
         address owner,
         uint256 epochLength,
         address appContract,
@@ -143,7 +143,7 @@ contract AuthorityTest is TestBase, OwnableTest {
 
         IAuthority authority = new Authority(owner, epochLength);
 
-        assertFalse(authority.wasClaimAccepted(appContract, claim));
+        assertFalse(authority.isOutputsMerkleRootValid(appContract, claim));
     }
 
     function _expectClaimEvents(

--- a/test/consensus/quorum/Quorum.t.sol
+++ b/test/consensus/quorum/Quorum.t.sol
@@ -53,12 +53,12 @@ library LibQuorum {
         );
     }
 
-    function wasClaimAccepted(
+    function isOutputsMerkleRootValid(
         IQuorum quorum,
         Claim calldata claim
     ) internal view returns (bool) {
         return
-            quorum.wasClaimAccepted(
+            quorum.isOutputsMerkleRootValid(
                 claim.appContract,
                 claim.outputHashesRootHash
             );
@@ -342,7 +342,7 @@ contract QuorumTest is TestBase {
         }
 
         assertEq(
-            quorum.wasClaimAccepted(claim),
+            quorum.isOutputsMerkleRootValid(claim),
             inFavorCount > (numOfValidators / 2)
         );
     }

--- a/test/consensus/quorum/Quorum.t.sol
+++ b/test/consensus/quorum/Quorum.t.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.22;
 
 import {Quorum} from "contracts/consensus/quorum/Quorum.sol";
 import {IQuorum} from "contracts/consensus/quorum/IQuorum.sol";
-import {IConsensus} from "contracts/consensus/IConsensus.sol";
+import {IClaimSubmitter} from "contracts/consensus/IClaimSubmitter.sol";
 
 import {TestBase} from "../../util/TestBase.sol";
 import {LibTopic} from "../../util/LibTopic.sol";
@@ -292,7 +292,7 @@ contract QuorumTest is TestBase {
 
             if (
                 entry.emitter == address(quorum) &&
-                entry.topics[0] == IConsensus.ClaimSubmission.selector
+                entry.topics[0] == IClaimSubmitter.ClaimSubmission.selector
             ) {
                 (
                     uint256 lastProcessedBlockNumber,
@@ -312,7 +312,7 @@ contract QuorumTest is TestBase {
 
             if (
                 entry.emitter == address(quorum) &&
-                entry.topics[0] == IConsensus.ClaimAcceptance.selector
+                entry.topics[0] == IClaimSubmitter.ClaimAcceptance.selector
             ) {
                 (
                     uint256 lastProcessedBlockNumber,

--- a/test/dapp/Application.t.sol
+++ b/test/dapp/Application.t.sol
@@ -42,7 +42,7 @@ contract ApplicationTest is TestBase, OwnableTest {
 
     IApplication _appContract;
     EtherReceiver _etherReceiver;
-    IConsensus _consensus;
+    Authority _authority;
     IERC20 _erc20Token;
     IERC721 _erc721Token;
     IERC1155 _erc1155SingleToken;
@@ -95,7 +95,7 @@ contract ApplicationTest is TestBase, OwnableTest {
                 address(0)
             )
         );
-        new Application(_consensus, address(0), _templateHash, new bytes(0));
+        new Application(_authority, address(0), _templateHash, new bytes(0));
     }
 
     function testConstructor(
@@ -347,13 +347,13 @@ contract ApplicationTest is TestBase, OwnableTest {
             _initialSupplies
         );
         _inputBox = new InputBox();
-        _consensus = new Authority(_authorityOwner, _epochLength);
+        _authority = new Authority(_authorityOwner, _epochLength);
         _dataAvailability = abi.encodeCall(
             DataAvailability.InputBox,
             (_inputBox)
         );
         _appContract = new Application(
-            _consensus,
+            _authority,
             _appOwner,
             _templateHash,
             _dataAvailability
@@ -518,7 +518,7 @@ contract ApplicationTest is TestBase, OwnableTest {
     function _submitClaim() internal {
         bytes32 claim = _emulator.getClaim();
         vm.prank(_authorityOwner);
-        _consensus.submitClaim(address(_appContract), 0, claim);
+        _authority.submitClaim(address(_appContract), 0, claim);
     }
 
     function _expectEmitOutputExecuted(

--- a/test/dapp/Application.t.sol
+++ b/test/dapp/Application.t.sol
@@ -516,9 +516,9 @@ contract ApplicationTest is TestBase, OwnableTest {
     }
 
     function _submitClaim() internal {
-        bytes32 claim = _emulator.getClaim();
+        bytes32 outputsMerkleRoot = _emulator.getOutputsMerkleRoot();
         vm.prank(_authorityOwner);
-        _authority.submitClaim(address(_appContract), 0, claim);
+        _authority.submitClaim(address(_appContract), 0, outputsMerkleRoot);
     }
 
     function _expectEmitOutputExecuted(
@@ -553,11 +553,11 @@ contract ApplicationTest is TestBase, OwnableTest {
         );
     }
 
-    function _expectRevertClaimNotAccepted(bytes32 claim) internal {
+    function _expectRevertClaimNotAccepted(bytes32 outputsMerkleRoot) internal {
         vm.expectRevert(
             abi.encodeWithSelector(
-                IApplication.ClaimNotAccepted.selector,
-                claim
+                IApplication.InvalidOutputsMerkleRoot.selector,
+                outputsMerkleRoot
             )
         );
     }

--- a/test/util/LibEmulator.sol
+++ b/test/util/LibEmulator.sol
@@ -54,32 +54,31 @@ library LibEmulator {
         return
             OutputValidityProof(
                 OutputIndex.unwrap(outputIndex),
-                getOutputHashesSiblings(
-                    outputHashes,
-                    OutputIndex.unwrap(outputIndex)
-                )
+                getOutputSiblings(outputHashes, OutputIndex.unwrap(outputIndex))
             );
     }
 
-    function getClaim(State storage state) internal view returns (bytes32) {
+    function getOutputsMerkleRoot(
+        State storage state
+    ) internal view returns (bytes32) {
         bytes32[] memory outputHashes;
 
         outputHashes = getOutputHashes(state.outputs);
 
-        return getOutputHashesRootHash(outputHashes);
+        return getOutputsMerkleRoot(outputHashes);
     }
 
     // -----------------
     // Merkle operations
     // -----------------
 
-    function getOutputHashesRootHash(
+    function getOutputsMerkleRoot(
         bytes32[] memory outputHashes
     ) internal pure returns (bytes32) {
         return outputHashes.merkleRoot(CanonicalMachine.LOG2_MAX_OUTPUTS);
     }
 
-    function getOutputHashesSiblings(
+    function getOutputSiblings(
         bytes32[] memory outputHashes,
         uint64 outputIndex
     ) internal pure returns (bytes32[] memory) {


### PR DESCRIPTION
- Create `IClaimSubmitter` interface
- Move definitions from `IConsensus` to `IClaimSubmitter`, leaving just the `isOutputsMerkleRootValid` function (former `wasClaimAccepted`)
- Make `IConsensus` inherit from ERC-165 interface
- Make consensus contracts implement ERC-165 (supporting `IClaimSubmitter`, `IAuthority`, and `IQuorum`, where applicable)
- Adjust nomenclature to make it explicit that the claim is the outputs Merkle root