### PR TITLE
Bump dependencies

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,7 @@ runs:
 
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         cache: 'pnpm'
 
     - name: Install Node packages

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,8 +10,6 @@ runs:
   using: 'composite'
   steps:
     - uses: pnpm/action-setup@v3
-      with:
-        version: 8
 
     - uses: actions/setup-node@v4
       with:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Set Foundry version
       id: set-foundry-version
       shell: bash
-      run: echo "foundry-version=v0.3.0" >> $GITHUB_OUTPUT
+      run: echo "foundry-version=v1.0.0" >> $GITHUB_OUTPUT
 
     - uses: foundry-rs/foundry-toolchain@v1
       with:

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,6 +4,7 @@ out = 'out'
 libs = ['node_modules', 'lib']
 solc_version = '0.8.23'
 via_ir = true
+optimizer = true
 
 [invariant]
 runs = 32


### PR DESCRIPTION
## pnpm

We used to provide a fixed pnpm version on the CI, but this is no longer necessary.
Thanks to the `packageManager` field on the `package.json` file, the version is detected automatically.

## Node.js

Since October 2024, Node.js 20 moved into "Maintenance" phase.
This PR changes CI to use [Node.js 22](https://nodejs.org/en/blog/announcements/v22-release-announce), which is currently in "Active" phase.

## Foundry

This PR also bumps Foundry from 0.3.0 to 1.0.0 (the latest stable release).
See the [migration guide](https://book.getfoundry.sh/guides/v1.0-migration).

### Solidity optimizer

One notable breaking change is that the Solidity optimizer is off by default.
So, we have to turn it on explicitly on the `foundry.toml` file.

### Bump `forge-std`

It is suggested to bump `forge-std` to the latest version because of cheat codes.