### PR TITLE
ci: do not create symlinks when publishing package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Create symlinks
-        run: yarn symlink
-
       - name: Create release PR or publish to npm
         uses: changesets/action@v1
         id: changeset


### PR DESCRIPTION
Doing `yarn symlink` before `yarn changeset publish` makes the package build process fail.