### PR TITLE
chore: bump pnpm from 9.9.0 to 10.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,5 @@
     "main": "./dist/src/types/index.js",
     "types": "./dist/src/types/index.d.ts",
     "license": "Apache-2.0",
-    "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1"
+    "packageManager": "pnpm@10.6.1"
 }


### PR DESCRIPTION
Also, remove hash from `packageManager` field.