### PR TITLE
Pin GH Actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,9 +9,9 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@v3
+    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version: 22
         cache: 'pnpm'
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: echo "foundry-version=v1.0.0" >> $GITHUB_OUTPUT
 
-    - uses: foundry-rs/foundry-toolchain@v1
+    - uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # 1.3.1
       with:
         version: ${{ steps.set-foundry-version.outputs.foundry-version }}
 

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "dependabot"
+    pull-request-branch-name:
+      separator: "/"

--- a/.github/workflows/check-code-format.yml
+++ b/.github/workflows/check-code-format.yml
@@ -6,7 +6,7 @@ jobs:
   check-code-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -6,7 +6,7 @@ jobs:
   check-commit-messages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -14,6 +14,6 @@ jobs:
         run: echo 'tag_prefix = "v"' > cog.toml
 
       - name: Run cocogitto
-        uses: cocogitto/cocogitto-action@v3
+        uses: cocogitto/cocogitto-action@c7a74f5406bab86da17da0f0e460a69f8219a68c # v3.11
         with:
           check-latest-tag-only: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,18 +17,18 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: ./.github/actions/setup
 
       - name: Generate documentation
         run: forge doc -b
 
-      - uses: actions/configure-pages@v4
+      - uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs/book
 
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.BOT_TOKEN }}
 
@@ -49,7 +49,7 @@ jobs:
     if: ${{ needs.version_or_publish.outputs.published == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -10,7 +10,7 @@ jobs:
     name: Upload contract artifacts to GitHub Releases
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: ./.github/actions/setup
         id: setup
@@ -42,7 +42,7 @@ jobs:
           FILEPATH: upload/rollups-contracts-${{ steps.extract_version.outputs.version }}-anvil-${{ steps.setup.outputs.foundry-version }}.tar.gz
 
       - name: Upload files to GitHub Releases
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
           files: upload/*
 


### PR DESCRIPTION
This pull request includes changes to update various GitHub Actions to specific commit hashes for better stability and reproducibility and mitigate supply chain attacks. Additionally, a new Dependabot configuration file has been added to automate dependency updates.

See: https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash

---

Updates to GitHub Actions:

* [`.github/actions/setup/action.yml`](diffhunk://#diff-9fb8259afcb532c9556e2d41ae1ee97cf6de54b486cef93a7ef1bf39433fa530L12-R14): Updated `pnpm/action-setup` to commit `a3252b78c470c02df07e9d59298aecedc3ccdd6d` and `actions/setup-node` to commit `cdca7365b2dadb8aad0a33bc7601856ffabcc48e`.
* [`.github/actions/setup/action.yml`](diffhunk://#diff-9fb8259afcb532c9556e2d41ae1ee97cf6de54b486cef93a7ef1bf39433fa530L28-R28): Updated `foundry-rs/foundry-toolchain` to commit `de808b1eea699e761c404bda44ba8f21aba30b2c`.
* `.github/workflows/check-code-format.yml`, `.github/workflows/check-commit-messages.yml`, `.github/workflows/docs.yml`, `.github/workflows/release.yml`, `.github/workflows/test.yml`, `.github/workflows/upload-artifacts.yml`: Updated `actions/checkout` to commit `11bd71901bbe5b1630ceea73d27597364c9af683`. [[1]](diffhunk://#diff-31ced261b814e1d35b2cace0d5b85a1a665ad44259e690195365765bad696007L9-R9) [[2]](diffhunk://#diff-607c8045fbe42730a8df4d3f026dadd6db05a2e1d919928ce7e8479d60e79caaL9-R17) [[3]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL20-R20) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L20-R20) [[5]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L18-R18) [[6]](diffhunk://#diff-a73d7897707443aa7ee7791fc69f4866bdc5e31fc6059d53e829ad8253e569feL13-R13)
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL29-R36): Updated `actions/configure-pages` to commit `1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d`, `actions/upload-pages-artifact` to commit `56afc609e74202658d3ffba0e8f6dda462b719fa`, and `actions/deploy-pages` to commit `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e`.
* [`.github/workflows/upload-artifacts.yml`](diffhunk://#diff-a73d7897707443aa7ee7791fc69f4866bdc5e31fc6059d53e829ad8253e569feL47-R47): Updated `softprops/action-gh-release` to commit `c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda`.

New Dependabot configuration:

* [`.github/dependabot.yaml`](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR1-R11): Added a new configuration file to automate dependency updates for GitHub Actions with a weekly schedule.