### PR TITLE
chore: make Soldeer generate remappings.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /out
 lcov.info
 state.json
+remappings.txt

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,5 @@
 [profile.default]
-src = "src"
-out = "out"
-libs = ["dependencies"]
+libs = []
 solc_version = "0.8.23"
 via_ir = true
 optimizer = true
@@ -13,9 +11,6 @@ line_length = 90
 runs = 32
 depth = 100
 fail_on_revert = true
-
-[soldeer]
-remappings_generate = false
 
 [dependencies]
 "@openzeppelin-contracts" = "5.2.0"

--- a/test/consensus/authority/Authority.t.sol
+++ b/test/consensus/authority/Authority.t.sol
@@ -4,8 +4,8 @@
 /// @title Authority Test
 pragma solidity ^0.8.22;
 
-import {Vm} from "forge-std-1.9.6/Vm.sol";
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Vm} from "forge-std-1.9.6/src/Vm.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 import {IERC165} from "@openzeppelin-contracts-5.2.0/utils/introspection/IERC165.sol";
 import {Ownable} from "@openzeppelin-contracts-5.2.0/access/Ownable.sol";

--- a/test/consensus/authority/AuthorityFactory.t.sol
+++ b/test/consensus/authority/AuthorityFactory.t.sol
@@ -4,8 +4,8 @@
 /// @title Authority Factory Test
 pragma solidity ^0.8.22;
 
-import {Vm} from "forge-std-1.9.6/Vm.sol";
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Vm} from "forge-std-1.9.6/src/Vm.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 import {Ownable} from "@openzeppelin-contracts-5.2.0/access/Ownable.sol";
 
 import {AuthorityFactory} from "src/consensus/authority/AuthorityFactory.sol";

--- a/test/consensus/quorum/Quorum.t.sol
+++ b/test/consensus/quorum/Quorum.t.sol
@@ -13,8 +13,8 @@ import {ERC165Test} from "../../util/ERC165Test.sol";
 import {LibAddressArray} from "../../util/LibAddressArray.sol";
 import {LibTopic} from "../../util/LibTopic.sol";
 
-import {Test} from "forge-std-1.9.6/Test.sol";
-import {Vm} from "forge-std-1.9.6/Vm.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
+import {Vm} from "forge-std-1.9.6/src/Vm.sol";
 
 struct Claim {
     address appContract;

--- a/test/consensus/quorum/QuorumFactory.t.sol
+++ b/test/consensus/quorum/QuorumFactory.t.sol
@@ -8,8 +8,8 @@ import {QuorumFactory} from "src/consensus/quorum/QuorumFactory.sol";
 import {IQuorumFactory} from "src/consensus/quorum/IQuorumFactory.sol";
 import {IQuorum} from "src/consensus/quorum/IQuorum.sol";
 
-import {Vm} from "forge-std-1.9.6/Vm.sol";
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Vm} from "forge-std-1.9.6/src/Vm.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 import {LibAddressArray} from "../../util/LibAddressArray.sol";
 

--- a/test/dapp/Application.t.sol
+++ b/test/dapp/Application.t.sol
@@ -28,8 +28,8 @@ import {IERC721} from "@openzeppelin-contracts-5.2.0/token/ERC721/IERC721.sol";
 import {Ownable} from "@openzeppelin-contracts-5.2.0/access/Ownable.sol";
 import {SafeERC20} from "@openzeppelin-contracts-5.2.0/token/ERC20/utils/SafeERC20.sol";
 
-import {Vm} from "forge-std-1.9.6/Vm.sol";
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Vm} from "forge-std-1.9.6/src/Vm.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 import {OwnableTest} from "../util/OwnableTest.sol";
 import {EtherReceiver} from "../util/EtherReceiver.sol";

--- a/test/dapp/ApplicationFactory.t.sol
+++ b/test/dapp/ApplicationFactory.t.sol
@@ -9,8 +9,8 @@ import {IApplicationFactory} from "src/dapp/IApplicationFactory.sol";
 import {IApplication} from "src/dapp/IApplication.sol";
 import {IOutputsMerkleRootValidator} from "src/consensus/IOutputsMerkleRootValidator.sol";
 
-import {Test} from "forge-std-1.9.6/Test.sol";
-import {Vm} from "forge-std-1.9.6/Vm.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
+import {Vm} from "forge-std-1.9.6/src/Vm.sol";
 
 contract ApplicationFactoryTest is Test {
     ApplicationFactory _factory;

--- a/test/dapp/SelfHostedApplicationFactory.t.sol
+++ b/test/dapp/SelfHostedApplicationFactory.t.sol
@@ -15,7 +15,7 @@ import {IApplication} from "src/dapp/IApplication.sol";
 import {ISelfHostedApplicationFactory} from "src/dapp/ISelfHostedApplicationFactory.sol";
 import {SelfHostedApplicationFactory} from "src/dapp/SelfHostedApplicationFactory.sol";
 
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 contract SelfHostedApplicationFactoryTest is Test {
     IAuthorityFactory authorityFactory;

--- a/test/inputs/InputBox.t.sol
+++ b/test/inputs/InputBox.t.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.22;
 
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 import {InputBox} from "src/inputs/InputBox.sol";
 import {IInputBox} from "src/inputs/IInputBox.sol";
 import {CanonicalMachine} from "src/common/CanonicalMachine.sol";

--- a/test/library/LibError.t.sol
+++ b/test/library/LibError.t.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.22;
 
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 import {LibError} from "src/library/LibError.sol";
 

--- a/test/library/LibMerkle32.t.sol
+++ b/test/library/LibMerkle32.t.sol
@@ -3,11 +3,11 @@
 
 pragma solidity ^0.8.22;
 
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 import {LibMerkle32} from "src/library/LibMerkle32.sol";
 
-import {console} from "forge-std-1.9.6/console.sol";
+import {console} from "forge-std-1.9.6/src/console.sol";
 
 library ExternalLibMerkle32 {
     using LibMerkle32 for bytes32[];

--- a/test/portals/ERC1155BatchPortal.t.sol
+++ b/test/portals/ERC1155BatchPortal.t.sol
@@ -11,7 +11,7 @@ import {IERC1155BatchPortal} from "src/portals/IERC1155BatchPortal.sol";
 import {IInputBox} from "src/inputs/IInputBox.sol";
 import {InputEncoding} from "src/common/InputEncoding.sol";
 
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 import {SimpleBatchERC1155} from "../util/SimpleERC1155.sol";
 

--- a/test/portals/ERC1155SinglePortal.t.sol
+++ b/test/portals/ERC1155SinglePortal.t.sol
@@ -11,7 +11,7 @@ import {IERC1155SinglePortal} from "src/portals/IERC1155SinglePortal.sol";
 import {IInputBox} from "src/inputs/IInputBox.sol";
 import {InputEncoding} from "src/common/InputEncoding.sol";
 
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 import {SimpleSingleERC1155} from "../util/SimpleERC1155.sol";
 

--- a/test/portals/ERC20Portal.t.sol
+++ b/test/portals/ERC20Portal.t.sol
@@ -11,7 +11,7 @@ import {IERC20Portal} from "src/portals/IERC20Portal.sol";
 import {IInputBox} from "src/inputs/IInputBox.sol";
 import {InputEncoding} from "src/common/InputEncoding.sol";
 
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 import {SimpleERC20} from "../util/SimpleERC20.sol";
 

--- a/test/portals/ERC721Portal.t.sol
+++ b/test/portals/ERC721Portal.t.sol
@@ -11,7 +11,7 @@ import {IERC721Portal} from "src/portals/IERC721Portal.sol";
 import {IInputBox} from "src/inputs/IInputBox.sol";
 import {InputEncoding} from "src/common/InputEncoding.sol";
 
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 import {SimpleERC721} from "../util/SimpleERC721.sol";
 

--- a/test/portals/EtherPortal.t.sol
+++ b/test/portals/EtherPortal.t.sol
@@ -8,7 +8,7 @@ import {IEtherPortal} from "src/portals/IEtherPortal.sol";
 import {IInputBox} from "src/inputs/IInputBox.sol";
 import {InputEncoding} from "src/common/InputEncoding.sol";
 
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 contract EtherPortalTest is Test {
     address _alice;

--- a/test/util/ERC165Test.sol
+++ b/test/util/ERC165Test.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.8;
 
 import {IERC165} from "@openzeppelin-contracts-5.2.0/utils/introspection/IERC165.sol";
 
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 /// @notice Tests contracts that implement ERC-165
 abstract contract ERC165Test is Test {

--- a/test/util/LibAddressArray.sol
+++ b/test/util/LibAddressArray.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.22;
 
-import {Vm} from "forge-std-1.9.6/Vm.sol";
+import {Vm} from "forge-std-1.9.6/src/Vm.sol";
 
 library LibAddressArray {
     function contains(address[] memory array, address elem)

--- a/test/util/LibAddressArray.t.sol
+++ b/test/util/LibAddressArray.t.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.22;
 
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 import {LibAddressArray} from "./LibAddressArray.sol";
 

--- a/test/util/OwnableTest.sol
+++ b/test/util/OwnableTest.sol
@@ -7,7 +7,7 @@ import {IOwnable} from "src/access/IOwnable.sol";
 
 import {Ownable} from "@openzeppelin-contracts-5.2.0/access/Ownable.sol";
 
-import {Test} from "forge-std-1.9.6/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 abstract contract OwnableTest is Test {
     /// @notice Get ownable contract to be tested


### PR DESCRIPTION
This change apparently improves support by code editors and Solidity plugins.