### PR TITLE
refactor!: rename events

### DIFF
--- a/.changeset/clean-sheep-dress.md
+++ b/.changeset/clean-sheep-dress.md
@@ -1,0 +1,11 @@
+---
+"@cartesi/rollups": major
+---
+
+Rename events:
+
+- `ClaimAcceptance` -> `ClaimAccepted`
+
+- `ClaimSubmission` -> `ClaimSubmitted`
+
+- `NewOutputsMerkleRootValidator` -> `OutputsMerkleRootValidatorChanged`

--- a/src/consensus/AbstractConsensus.sol
+++ b/src/consensus/AbstractConsensus.sol
@@ -55,13 +55,13 @@ abstract contract AbstractConsensus is IConsensus, ERC165 {
     /// @param appContract The application contract address
     /// @param lastProcessedBlockNumber The number of the last processed block
     /// @param outputsMerkleRoot The output Merkle root hash
-    /// @dev Emits a `ClaimAcceptance` event.
+    /// @dev Emits a `ClaimAccepted` event.
     function _acceptClaim(
         address appContract,
         uint256 lastProcessedBlockNumber,
         bytes32 outputsMerkleRoot
     ) internal {
         _validOutputsMerkleRoots[appContract][outputsMerkleRoot] = true;
-        emit ClaimAcceptance(appContract, lastProcessedBlockNumber, outputsMerkleRoot);
+        emit ClaimAccepted(appContract, lastProcessedBlockNumber, outputsMerkleRoot);
     }
 }

--- a/src/consensus/IConsensus.sol
+++ b/src/consensus/IConsensus.sol
@@ -13,8 +13,8 @@ import {IOutputsMerkleRootValidator} from "./IOutputsMerkleRootValidator.sol";
 /// @notice The claim that validators may submit to the consensus contract
 /// is the root of this Merkle tree after processing all base layer blocks until some height.
 /// @notice A validator should be able to save transaction fees by not submitting a claim if it was...
-/// - already submitted by the validator (see the `ClaimSubmission` event) or;
-/// - already accepted by the consensus (see the `ClaimAcceptance` event).
+/// - already submitted by the validator (see the `ClaimSubmitted` event) or;
+/// - already accepted by the consensus (see the `ClaimAccepted` event).
 /// @notice The acceptance criteria for claims may depend on the type of consensus, and is not specified by this interface.
 /// For example, a claim may be accepted if it was...
 /// - submitted by an authority or;
@@ -27,7 +27,7 @@ interface IConsensus is IOutputsMerkleRootValidator {
     /// @param appContract The application contract address
     /// @param lastProcessedBlockNumber The number of the last processed block
     /// @param outputsMerkleRoot The outputs Merkle root
-    event ClaimSubmission(
+    event ClaimSubmitted(
         address indexed submitter,
         address indexed appContract,
         uint256 lastProcessedBlockNumber,
@@ -38,7 +38,7 @@ interface IConsensus is IOutputsMerkleRootValidator {
     /// @param appContract The application contract address
     /// @param lastProcessedBlockNumber The number of the last processed block
     /// @param outputsMerkleRoot The outputs Merkle root
-    event ClaimAcceptance(
+    event ClaimAccepted(
         address indexed appContract,
         uint256 lastProcessedBlockNumber,
         bytes32 outputsMerkleRoot
@@ -48,8 +48,8 @@ interface IConsensus is IOutputsMerkleRootValidator {
     /// @param appContract The application contract address
     /// @param lastProcessedBlockNumber The number of the last processed block
     /// @param outputsMerkleRoot The outputs Merkle root
-    /// @dev MUST fire a `ClaimSubmission` event.
-    /// @dev MAY fire a `ClaimAcceptance` event, if the acceptance criteria is met.
+    /// @dev MUST fire a `ClaimSubmitted` event.
+    /// @dev MAY fire a `ClaimAccepted` event, if the acceptance criteria is met.
     function submitClaim(
         address appContract,
         uint256 lastProcessedBlockNumber,

--- a/src/consensus/authority/Authority.sol
+++ b/src/consensus/authority/Authority.sol
@@ -29,7 +29,7 @@ contract Authority is IAuthority, AbstractConsensus, Ownable {
         uint256 lastProcessedBlockNumber,
         bytes32 outputsMerkleRoot
     ) external override onlyOwner {
-        emit ClaimSubmission(
+        emit ClaimSubmitted(
             msg.sender, appContract, lastProcessedBlockNumber, outputsMerkleRoot
         );
         _acceptClaim(appContract, lastProcessedBlockNumber, outputsMerkleRoot);

--- a/src/consensus/quorum/Quorum.sol
+++ b/src/consensus/quorum/Quorum.sol
@@ -68,7 +68,7 @@ contract Quorum is IQuorum, AbstractConsensus {
         uint256 id = _validatorId[msg.sender];
         require(id > 0, "Quorum: caller is not validator");
 
-        emit ClaimSubmission(
+        emit ClaimSubmitted(
             msg.sender, appContract, lastProcessedBlockNumber, outputsMerkleRoot
         );
 

--- a/src/dapp/Application.sol
+++ b/src/dapp/Application.sol
@@ -107,7 +107,7 @@ contract Application is
         IOutputsMerkleRootValidator newOutputsMerkleRootValidator
     ) external override onlyOwner {
         _outputsMerkleRootValidator = newOutputsMerkleRootValidator;
-        emit NewOutputsMerkleRootValidator(newOutputsMerkleRootValidator);
+        emit OutputsMerkleRootValidatorChanged(newOutputsMerkleRootValidator);
     }
 
     function wasOutputExecuted(uint256 outputIndex)

--- a/src/dapp/IApplication.sol
+++ b/src/dapp/IApplication.sol
@@ -29,7 +29,7 @@ interface IApplication is IOwnable {
 
     /// @notice MUST trigger when a new outputs Merkle root validator is chosen.
     /// @param newOutputsMerkleRootValidator The new outputs Merkle root validator
-    event NewOutputsMerkleRootValidator(
+    event OutputsMerkleRootValidatorChanged(
         IOutputsMerkleRootValidator newOutputsMerkleRootValidator
     );
 

--- a/test/consensus/authority/Authority.t.sol
+++ b/test/consensus/authority/Authority.t.sol
@@ -160,11 +160,11 @@ contract AuthorityTest is Test, ERC165Test, OwnableTest {
         bytes32 claim
     ) internal {
         vm.expectEmit(true, true, false, true, address(authority));
-        emit IConsensus.ClaimSubmission(
+        emit IConsensus.ClaimSubmitted(
             owner, appContract, lastProcessedBlockNumber, claim
         );
 
         vm.expectEmit(true, false, false, true, address(authority));
-        emit IConsensus.ClaimAcceptance(appContract, lastProcessedBlockNumber, claim);
+        emit IConsensus.ClaimAccepted(appContract, lastProcessedBlockNumber, claim);
     }
 }

--- a/test/consensus/quorum/Quorum.t.sol
+++ b/test/consensus/quorum/Quorum.t.sol
@@ -296,7 +296,7 @@ contract QuorumTest is Test, ERC165Test {
 
             if (
                 entry.emitter == address(quorum)
-                    && entry.topics[0] == IConsensus.ClaimSubmission.selector
+                    && entry.topics[0] == IConsensus.ClaimSubmitted.selector
             ) {
                 (uint256 lastProcessedBlockNumber, bytes32 outputHashesRootHash) =
                     abi.decode(entry.data, (uint256, bytes32));
@@ -311,7 +311,7 @@ contract QuorumTest is Test, ERC165Test {
 
             if (
                 entry.emitter == address(quorum)
-                    && entry.topics[0] == IConsensus.ClaimAcceptance.selector
+                    && entry.topics[0] == IConsensus.ClaimAccepted.selector
             ) {
                 (uint256 lastProcessedBlockNumber, bytes32 outputHashesRootHash) =
                     abi.decode(entry.data, (uint256, bytes32));

--- a/test/dapp/Application.t.sol
+++ b/test/dapp/Application.t.sol
@@ -144,7 +144,7 @@ contract ApplicationTest is Test, OwnableTest {
     ) external {
         vm.prank(_appOwner);
         vm.expectEmit(false, false, false, true, address(_appContract));
-        emit IApplication.NewOutputsMerkleRootValidator(newOutputsMerkleRootValidator);
+        emit IApplication.OutputsMerkleRootValidatorChanged(newOutputsMerkleRootValidator);
         _appContract.migrateToOutputsMerkleRootValidator(newOutputsMerkleRootValidator);
         assertEq(
             address(_appContract.getOutputsMerkleRootValidator()),


### PR DESCRIPTION
This PR aims to bring a more consistent nomenclature for events.
We are favoring here event names ending with a verb in simple past tense.