### PR TITLE
Add `getDeploymentBlockNumber` function to `IApplication` interface

### DIFF
--- a/.changeset/shiny-frogs-go.md
+++ b/.changeset/shiny-frogs-go.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": minor
+---
+
+Add `getDeploymentBlockNumber` function to `IApplication` interface

--- a/src/dapp/Application.sol
+++ b/src/dapp/Application.sol
@@ -32,6 +32,9 @@ contract Application is
     using LibAddress for address;
     using LibOutputValidityProof for OutputValidityProof;
 
+    /// @notice Deployment block number
+    uint256 immutable _deploymentBlockNumber = block.number;
+
     /// @notice The initial machine state hash.
     /// @dev See the `getTemplateHash` function.
     bytes32 internal immutable _templateHash;
@@ -158,6 +161,11 @@ contract Application is
 
     function getDataAvailability() external view override returns (bytes memory) {
         return _dataAvailability;
+    }
+
+    /// @inheritdoc IApplication
+    function getDeploymentBlockNumber() external view override returns (uint256) {
+        return _deploymentBlockNumber;
     }
 
     function owner() public view override(IOwnable, Ownable) returns (address) {

--- a/src/dapp/Application.sol
+++ b/src/dapp/Application.sol
@@ -72,6 +72,7 @@ contract Application is
     ///      the backend of it, then please do so through the Ether portal contract.
     receive() external payable {}
 
+    /// @inheritdoc IApplication
     function executeOutput(bytes calldata output, OutputValidityProof calldata proof)
         external
         override
@@ -106,6 +107,7 @@ contract Application is
         emit OutputExecuted(outputIndex, output);
     }
 
+    /// @inheritdoc IApplication
     function migrateToOutputsMerkleRootValidator(
         IOutputsMerkleRootValidator newOutputsMerkleRootValidator
     ) external override onlyOwner {
@@ -113,6 +115,7 @@ contract Application is
         emit NewOutputsMerkleRootValidator(newOutputsMerkleRootValidator);
     }
 
+    /// @inheritdoc IApplication
     function wasOutputExecuted(uint256 outputIndex)
         external
         view
@@ -122,6 +125,7 @@ contract Application is
         return _executed.get(outputIndex);
     }
 
+    /// @inheritdoc IApplication
     function validateOutput(bytes calldata output, OutputValidityProof calldata proof)
         public
         view
@@ -130,6 +134,7 @@ contract Application is
         validateOutputHash(keccak256(output), proof);
     }
 
+    /// @inheritdoc IApplication
     function validateOutputHash(bytes32 outputHash, OutputValidityProof calldata proof)
         public
         view
@@ -146,10 +151,12 @@ contract Application is
         }
     }
 
+    /// @inheritdoc IApplication
     function getTemplateHash() external view override returns (bytes32) {
         return _templateHash;
     }
 
+    /// @inheritdoc IApplication
     function getOutputsMerkleRootValidator()
         external
         view
@@ -159,6 +166,7 @@ contract Application is
         return _outputsMerkleRootValidator;
     }
 
+    /// @inheritdoc IApplication
     function getDataAvailability() external view override returns (bytes memory) {
         return _dataAvailability;
     }
@@ -168,14 +176,17 @@ contract Application is
         return _deploymentBlockNumber;
     }
 
+    /// @inheritdoc Ownable
     function owner() public view override(IOwnable, Ownable) returns (address) {
         return super.owner();
     }
 
+    /// @inheritdoc Ownable
     function renounceOwnership() public override(IOwnable, Ownable) {
         super.renounceOwnership();
     }
 
+    /// @inheritdoc Ownable
     function transferOwnership(address newOwner) public override(IOwnable, Ownable) {
         super.transferOwnership(newOwner);
     }

--- a/src/dapp/IApplication.sol
+++ b/src/dapp/IApplication.sol
@@ -120,4 +120,7 @@ interface IApplication is IOwnable {
     /// @return Solidity ABI-encoded function call that describes
     /// the source of inputs that should be fed to the application.
     function getDataAvailability() external view returns (bytes memory);
+
+    /// @notice Get number of block in which contract was deployed
+    function getDeploymentBlockNumber() external view returns (uint256);
 }

--- a/src/inputs/InputBox.sol
+++ b/src/inputs/InputBox.sol
@@ -9,14 +9,10 @@ import {Inputs} from "../common/Inputs.sol";
 
 contract InputBox is IInputBox {
     /// @notice Deployment block number
-    uint256 immutable _deploymentBlockNumber;
+    uint256 immutable _deploymentBlockNumber = block.number;
 
     /// @notice Mapping of application contract addresses to arrays of input hashes.
     mapping(address => bytes32[]) private _inputBoxes;
-
-    constructor() {
-        _deploymentBlockNumber = block.number;
-    }
 
     /// @inheritdoc IInputBox
     function addInput(address appContract, bytes calldata payload)

--- a/test/dapp/Application.t.sol
+++ b/test/dapp/Application.t.sol
@@ -100,12 +100,15 @@ contract ApplicationTest is Test, OwnableTest {
     }
 
     function testConstructor(
+        uint256 blockNumber,
         IOutputsMerkleRootValidator outputsMerkleRootValidator,
         address owner,
         bytes32 templateHash,
         bytes calldata dataAvailability
     ) external {
         vm.assume(owner != address(0));
+
+        vm.roll(blockNumber);
 
         vm.expectEmit(true, true, false, false);
         emit Ownable.OwnershipTransferred(address(0), owner);
@@ -121,6 +124,7 @@ contract ApplicationTest is Test, OwnableTest {
         assertEq(appContract.owner(), owner);
         assertEq(appContract.getTemplateHash(), templateHash);
         assertEq(appContract.getDataAvailability(), dataAvailability);
+        assertEq(appContract.getDeploymentBlockNumber(), blockNumber);
     }
 
     // ---------------------------------------

--- a/test/dapp/ApplicationFactory.t.sol
+++ b/test/dapp/ApplicationFactory.t.sol
@@ -20,12 +20,15 @@ contract ApplicationFactoryTest is Test {
     }
 
     function testNewApplication(
+        uint256 blockNumber,
         IOutputsMerkleRootValidator outputsMerkleRootValidator,
         address appOwner,
         bytes32 templateHash,
         bytes calldata dataAvailability
     ) public {
         vm.assume(appOwner != address(0));
+
+        vm.roll(blockNumber);
 
         IApplication appContract = _factory.newApplication(
             outputsMerkleRootValidator, appOwner, templateHash, dataAvailability
@@ -38,9 +41,11 @@ contract ApplicationFactoryTest is Test {
         assertEq(appContract.owner(), appOwner);
         assertEq(appContract.getTemplateHash(), templateHash);
         assertEq(appContract.getDataAvailability(), dataAvailability);
+        assertEq(appContract.getDeploymentBlockNumber(), blockNumber);
     }
 
     function testNewApplicationDeterministic(
+        uint256 blockNumber,
         IOutputsMerkleRootValidator outputsMerkleRootValidator,
         address appOwner,
         bytes32 templateHash,
@@ -48,6 +53,8 @@ contract ApplicationFactoryTest is Test {
         bytes32 salt
     ) public {
         vm.assume(appOwner != address(0));
+
+        vm.roll(blockNumber);
 
         address precalculatedAddress = _factory.calculateApplicationAddress(
             outputsMerkleRootValidator, appOwner, templateHash, dataAvailability, salt
@@ -67,6 +74,7 @@ contract ApplicationFactoryTest is Test {
         assertEq(appContract.owner(), appOwner);
         assertEq(appContract.getTemplateHash(), templateHash);
         assertEq(appContract.getDataAvailability(), dataAvailability);
+        assertEq(appContract.getDeploymentBlockNumber(), blockNumber);
 
         precalculatedAddress = _factory.calculateApplicationAddress(
             outputsMerkleRootValidator, appOwner, templateHash, dataAvailability, salt


### PR DESCRIPTION
This function aims to improve the node's capability of listening to events emitted by the `Application` contract, for those deployed many blocks after the `InputBox` contract.

This PR also makes some small related improvements.