### PR TITLE
Add additional checks to consensus contracts

### DIFF
--- a/.changeset/nine-poems-burn.md
+++ b/.changeset/nine-poems-burn.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": minor
+---
+
+Make `Authority` and `Quorum` validate last processed block number

--- a/.changeset/petite-numbers-read.md
+++ b/.changeset/petite-numbers-read.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": major
+---
+
+Avoid conflicting claims in Quorum

--- a/.changeset/sweet-tools-taste.md
+++ b/.changeset/sweet-tools-taste.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": patch
+---
+
+Bump solc from 0.8.23 to 0.8.29

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
 libs = []
-solc_version = "0.8.23"
+solc_version = "0.8.29"
 via_ir = true
 optimizer = true
 

--- a/src/consensus/IConsensus.sol
+++ b/src/consensus/IConsensus.sol
@@ -38,11 +38,30 @@ interface IConsensus is IOutputsMerkleRootValidator {
     /// @param appContract The application contract address
     /// @param lastProcessedBlockNumber The number of the last processed block
     /// @param outputsMerkleRoot The outputs Merkle root
+    /// @dev For each application and lastProcessedBlockNumber,
+    /// there can be at most one accepted claim.
     event ClaimAccepted(
         address indexed appContract,
         uint256 lastProcessedBlockNumber,
         bytes32 outputsMerkleRoot
     );
+
+    /// @notice The claim contains the number of a block that is not
+    /// at the end of an epoch (its modulo epoch length is not epoch length - 1).
+    /// @param lastProcessedBlockNumber The number of the last processed block
+    /// @param epochLength The epoch length
+    error NotEpochFinalBlock(uint256 lastProcessedBlockNumber, uint256 epochLength);
+
+    /// @notice The claim contains the number of a block in the future
+    /// (it is greater or equal to the current block number).
+    /// @param lastProcessedBlockNumber The number of the last processed block
+    /// @param currentBlockNumber The number of the current block
+    error NotPastBlock(uint256 lastProcessedBlockNumber, uint256 currentBlockNumber);
+
+    /// @notice A claim for that application and epoch was already submitted by the validator.
+    /// @param appContract The application contract address
+    /// @param lastProcessedBlockNumber The number of the last processed block
+    error NotFirstClaim(address appContract, uint256 lastProcessedBlockNumber);
 
     /// @notice Submit a claim to the consensus.
     /// @param appContract The application contract address

--- a/src/consensus/quorum/IQuorum.sol
+++ b/src/consensus/quorum/IQuorum.sol
@@ -27,6 +27,27 @@ interface IQuorum is IConsensus {
     /// @dev Invalid IDs map to address zero.
     function validatorById(uint256 id) external view returns (address);
 
+    /// @notice Get the number of validators in favor of any claim in a given epoch.
+    /// @param appContract The application contract address
+    /// @param lastProcessedBlockNumber The number of the last processed block
+    /// @return Number of validators in favor of any claim in the epoch
+    function numOfValidatorsInFavorOfAnyClaimInEpoch(
+        address appContract,
+        uint256 lastProcessedBlockNumber
+    ) external view returns (uint256);
+
+    /// @notice Check whether a validator is in favor of any claim in a given epoch.
+    /// @param appContract The application contract address
+    /// @param lastProcessedBlockNumber The number of the last processed block
+    /// @param id The ID of the validator
+    /// @return Whether validator is in favor of any claim in the epoch
+    /// @dev Assumes the provided ID is valid.
+    function isValidatorInFavorOfAnyClaimInEpoch(
+        address appContract,
+        uint256 lastProcessedBlockNumber,
+        uint256 id
+    ) external view returns (bool);
+
     /// @notice Get the number of validators in favor of a claim.
     /// @param appContract The application contract address
     /// @param lastProcessedBlockNumber The number of the last processed block

--- a/src/consensus/quorum/Quorum.sol
+++ b/src/consensus/quorum/Quorum.sol
@@ -68,6 +68,8 @@ contract Quorum is IQuorum, AbstractConsensus {
         uint256 id = _validatorId[msg.sender];
         require(id > 0, "Quorum: caller is not validator");
 
+        _validateLastProcessedBlockNumber(lastProcessedBlockNumber);
+
         emit ClaimSubmitted(
             msg.sender, appContract, lastProcessedBlockNumber, outputsMerkleRoot
         );


### PR DESCRIPTION
This PR adds the following checks to `Authority` and `Quorum`:

- `lastProcessedBlockNumber < block.number`: validators cannot process blocks in the future
- `lastProcessedBlockNumber % epochLength == (epochLength - 1)`: validators have to validate blocks until the last block of an epoch
- there cannot be two accepted claims for the same epoch

The last point is implemented differently for `Authority` and `Quorum`:

- Authority stores the set of epochs for which a claim was accepted.
- Quorum stores the set of validators that have submitted a claim for a given epoch.

Both contracts use OpenZeppelin's bitmap data structure to store sets.
In Authority, epochs are identified by their number (`lastProcessedBlockNumber / epochLength`)
In Quorum, validators are identified by their ID.
Because of how OpenZepplein implements bitmaps and how these numbers are close to one another, this saves gas because fewer storage slots have to be read/written.

Other notable things about this PR:

- We've bumped solc from 0.8.23 to 0.8.29 (to use `require(bool, CustomError)` syntax)
- Adds custom errors to `IConsensus` for each of these checks
- In the case of Quorum, if a validator submits the same claim twice, it is simply ignored, and no error is reverted (idempotence). This behavior/feature is a consequence of implementation details.
- Added two new view functions to `IQuorum` to consult information about validators that have submitted any claim for a particular epoch (basically exposing the newly-added state variables through the interface).
- Added tests to cover all cases