### PR TITLE
fix: add dotfiles to `.soldeerignore`

### DIFF
--- a/.changeset/dull-ravens-relax.md
+++ b/.changeset/dull-ravens-relax.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": patch
+---
+
+Add dotfiles to `.soldeerignore`

--- a/.soldeerignore
+++ b/.soldeerignore
@@ -1,5 +1,10 @@
 .changeset
 .github
+.gitignore
+.soldeerignore
+AUTHORS
+CHANGELOG.md
+cannonfile.toml
 package.json
 pnpm-lock.yaml
 test


### PR DESCRIPTION
The problem seemed to be caused by the fact that the Soldeer package included the files `.soldeerignore` and `.gitignore`, which are considered sensitive by Soldeer (although they are not). Soldeer emits a warning and expects the user to choose between yes and no. Since the command is run on the terminal, it raises an IO error, because there is no terminal present.

This PR adds these files to the `.soldeerignore` file so that they are not included in the Soldeer package. These files shouldn't be necessary for users of the Soldeer package, because `.soldeerignore` serves just during the Soldeer package publishing process, and `.gitignore` is only used when git "sees" the directory, but the `dependencies` directory is usually included in the `.gitignore` either way.

This PR also instructs Soldeer to ignore `AUTHORS`, `CHANGELOG.md`, and `cannonfile.toml`, as they are not necessary for projects that depend on our Solidity contracts. This helps reduce the size of the package.

Closes #400