### PR TITLE
Run CI on `next/*` branches

### DIFF
--- a/.github/workflows/check-code-format.yml
+++ b/.github/workflows/check-code-format.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - release/*
+      - next/*
 
 jobs:
   check-code-format:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - release/*
+      - next/*
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - release/*
+      - next/*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
We're transitioning to using `next/*` branches for pre-releases.
To leverage CI checks on them, we need to update some workflow files.