### PR TITLE
Use API token when publishing to Soldeer

### DIFF
--- a/.changeset/funny-waves-film.md
+++ b/.changeset/funny-waves-film.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": patch
+---
+
+Use API token when publishing to Soldeer

--- a/.github/workflows/upload-contracts.yml
+++ b/.github/workflows/upload-contracts.yml
@@ -19,13 +19,8 @@ jobs:
         id: extract_version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Log in with Soldeer credentials
-        run: forge soldeer login --email "$SOLDEER_EMAIL" --password "$SOLDEER_PASSWORD"
-        env:
-          SOLDEER_EMAIL: ${{ secrets.SOLDEER_EMAIL }}
-          SOLDEER_PASSWORD: ${{ secrets.SOLDEER_PASSWORD }}
-
       - name: Push package to Soldeer.xyz
         run: forge soldeer push "cartesi-rollups-contracts~$VERSION"
         env:
+          SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_API_TOKEN }}
           VERSION: ${{ steps.extract_version.outputs.version }}


### PR DESCRIPTION
[Soldeer 0.7.0](https://github.com/mario-eth/soldeer/releases/tag/v0.7.0) added support to API tokens when publishing to the registry and deprecated authentication through e-mail and password credentials:

> The option to login via email and password will be removed in a future version of Soldeer. Please update your usage by either using `soldeer login --token [YOUR CLI TOKEN]` or passing the `SOLDEER_API_TOKEN` environment variable to the `push` command.

[Foundry 1.4.0](https://github.com/foundry-rs/foundry/releases/tag/v1.4.0) bumped Soldeer from 0.6.1 to 0.8.0, therefore including this feature. In order to avoid our CI from not being able to publish the contracts to Soldeer, we should transition from e-mail and password credentials to API tokens.