### PR TITLE
Fix deployment Forge script

### DIFF
--- a/.changeset/dull-geese-brush.md
+++ b/.changeset/dull-geese-brush.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": patch
+---
+
+Fix deployment Forge script


### PR DESCRIPTION
## Problem

After #462 was merged, I decided to release an alpha version just so we could test the CI devnet build and it surely enough exposed a bug in the deployment Forge script: The `vm.getDeployment` cheatcode fails on simulation because it tries to access a broadcast file which does not exist. You see, this function basically attempts to retrieve the last deployment of a given contract to the current chain. So, on the first time you run the script, there is no previous deployment (during script simulation on a local fork of the network to which the contracts are being deployed). That is why the deployment Forge script, and, by extension, the devet build failed. This bug was not caught locally because my environment already contained a broadcast directory with transactions to the Anvil devnet (chain ID 31337). Had I cleaned my environment, or were the devnet build run on the PR CI, this bug would have been more likely caught at an earlier time.

## Solution

The solution is to not rely on broadcasts on first-time deployments. Since we are simulating both the deployment and the serialization of addresses in the same script entry-point, it would be simpler to simply store the addresses of deployments on variables that are later accessed for serialization. Straightforward, and less reliant on Forge cheatcodes. This is basically what @ZzzzHui had originally implemented, and was (mistakingly) changed by me to use `vm.getDeployment`. 