### PR TITLE
Add monotonic counter for submitted claims

### DIFF
--- a/src/consensus/AbstractConsensus.sol
+++ b/src/consensus/AbstractConsensus.sol
@@ -19,6 +19,9 @@ abstract contract AbstractConsensus is IConsensus, ERC165 {
     /// @notice Number of claims accepted by the consensus.
     /// @dev Must be monotonically non-decreasing in time
     uint256 _numOfAcceptedClaims;
+    /// @notice Number of claims submitted to the consensus.
+    /// @dev Must be monotonically non-decreasing in time
+    uint256 _numOfSubmittedClaims;
 
     /// @param epochLength The epoch length
     /// @dev Reverts if the epoch length is zero.
@@ -45,6 +48,11 @@ abstract contract AbstractConsensus is IConsensus, ERC165 {
     /// @inheritdoc IConsensus
     function getNumberOfAcceptedClaims() external view override returns (uint256) {
         return _numOfAcceptedClaims;
+    }
+
+    /// @inheritdoc IConsensus
+    function getNumberOfSubmittedClaims() external view override returns (uint256) {
+        return _numOfSubmittedClaims;
     }
 
     /// @inheritdoc ERC165
@@ -76,6 +84,24 @@ abstract contract AbstractConsensus is IConsensus, ERC165 {
                 NotPastBlock(lastProcessedBlockNumber, upperBound)
             );
         }
+    }
+
+    /// @notice Submit a claim.
+    /// @param submitter The submitter address
+    /// @param appContract The application contract address
+    /// @param lastProcessedBlockNumber The number of the last processed block
+    /// @param outputsMerkleRoot The output Merkle root hash
+    /// @dev Emits a `ClaimSubmitted` event.
+    function _submitClaim(
+        address submitter,
+        address appContract,
+        uint256 lastProcessedBlockNumber,
+        bytes32 outputsMerkleRoot
+    ) internal {
+        emit ClaimSubmitted(
+            submitter, appContract, lastProcessedBlockNumber, outputsMerkleRoot
+        );
+        ++_numOfSubmittedClaims;
     }
 
     /// @notice Accept a claim.

--- a/src/consensus/IConsensus.sol
+++ b/src/consensus/IConsensus.sol
@@ -82,4 +82,7 @@ interface IConsensus is IOutputsMerkleRootValidator {
 
     /// @notice Get the number of claims accepted by the consensus.
     function getNumberOfAcceptedClaims() external view returns (uint256);
+
+    /// @notice Get the number of claims submitted to the consensus.
+    function getNumberOfSubmittedClaims() external view returns (uint256);
 }

--- a/src/consensus/authority/Authority.sol
+++ b/src/consensus/authority/Authority.sol
@@ -46,9 +46,7 @@ contract Authority is IAuthority, AbstractConsensus, Ownable {
             !bitmap.get(epochNumber), NotFirstClaim(appContract, lastProcessedBlockNumber)
         );
 
-        emit ClaimSubmitted(
-            msg.sender, appContract, lastProcessedBlockNumber, outputsMerkleRoot
-        );
+        _submitClaim(msg.sender, appContract, lastProcessedBlockNumber, outputsMerkleRoot);
 
         _acceptClaim(appContract, lastProcessedBlockNumber, outputsMerkleRoot);
 

--- a/src/consensus/quorum/Quorum.sol
+++ b/src/consensus/quorum/Quorum.sol
@@ -76,22 +76,21 @@ contract Quorum is IQuorum, AbstractConsensus {
 
         _validateLastProcessedBlockNumber(lastProcessedBlockNumber);
 
-        emit ClaimSubmitted(
-            msg.sender, appContract, lastProcessedBlockNumber, outputsMerkleRoot
-        );
-
         Votes storage votes =
             _getVotes(appContract, lastProcessedBlockNumber, outputsMerkleRoot);
 
         Votes storage allVotes = _getAllVotes(appContract, lastProcessedBlockNumber);
 
-        // Skip storage changes if validator already voted
-        // for the same exact claim before
+        // Skip if validator already voted for the same exact claim before
         if (!votes.inFavorById.get(id)) {
             // Revert if validator has submitted another claim for the same epoch
             require(
                 !allVotes.inFavorById.get(id),
                 NotFirstClaim(appContract, lastProcessedBlockNumber)
+            );
+
+            _submitClaim(
+                msg.sender, appContract, lastProcessedBlockNumber, outputsMerkleRoot
             );
 
             // Register vote (for any claim in the epoch)

--- a/test/consensus/authority/Authority.t.sol
+++ b/test/consensus/authority/Authority.t.sol
@@ -133,6 +133,7 @@ contract AuthorityTest is Test, ERC165Test, OwnableTest {
             authority.submitClaim(app, blockNum - 1, claims[i]);
 
             assertEq(authority.getNumberOfAcceptedClaims(), i + 1);
+            assertEq(authority.getNumberOfSubmittedClaims(), i + 1);
         }
     }
 
@@ -172,6 +173,7 @@ contract AuthorityTest is Test, ERC165Test, OwnableTest {
         authority.submitClaim(appContract, lastProcessedBlockNumber, claim2);
 
         assertEq(authority.getNumberOfAcceptedClaims(), 1);
+        assertEq(authority.getNumberOfSubmittedClaims(), 1);
     }
 
     function testSubmitClaimNotEpochFinalBlock(
@@ -206,6 +208,7 @@ contract AuthorityTest is Test, ERC165Test, OwnableTest {
         vm.prank(owner);
         authority.submitClaim(appContract, lastProcessedBlockNumber, claim);
         assertEq(authority.getNumberOfAcceptedClaims(), 0);
+        assertEq(authority.getNumberOfSubmittedClaims(), 0);
     }
 
     function testSubmitClaimNotPastBlock(
@@ -236,6 +239,7 @@ contract AuthorityTest is Test, ERC165Test, OwnableTest {
         vm.prank(owner);
         authority.submitClaim(appContract, lastProcessedBlockNumber, claim);
         assertEq(authority.getNumberOfAcceptedClaims(), 0);
+        assertEq(authority.getNumberOfSubmittedClaims(), 0);
     }
 
     function testIsOutputsMerkleRootValid(


### PR DESCRIPTION
Added getNumberOfSubmittedClaims() to IConsensus interface to expose a monotonic counter of submitted claims, as described in #478 

Behavior:
- Authority: 1 submission/increment per epoch, resubmission reverts;
- Quorum: 1 submission/increment per validator per epoch, same validator resubmission is silently ignored;

( I’ve also updated the tests ).