### PR TITLE
Per-app submitted/accepted claim counters

### DIFF
--- a/.changeset/little-stars-battle.md
+++ b/.changeset/little-stars-battle.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": major
+---
+
+Add `appContract` parameter to `getNumberOf{Submitted,Accepted}Claims` functions

--- a/src/consensus/AbstractConsensus.sol
+++ b/src/consensus/AbstractConsensus.sol
@@ -31,13 +31,15 @@ abstract contract AbstractConsensus is IConsensus, ERC165, ApplicationChecker {
     /// by application contract address.
     mapping(address => bytes32) private _lastFinalizedMachineMerkleRoots;
 
-    /// @notice Number of claims accepted by the consensus.
+    /// @notice Indexes number of claims accepted to the consensus
+    /// by application contract address.
     /// @dev Must be monotonically non-decreasing in time
-    uint256 private _numOfAcceptedClaims;
+    mapping(address => uint256) private _numOfAcceptedClaims;
 
-    /// @notice Number of claims submitted to the consensus.
+    /// @notice Indexes number of claims submitted to the consensus
+    /// by application contract address.
     /// @dev Must be monotonically non-decreasing in time
-    uint256 private _numOfSubmittedClaims;
+    mapping(address => uint256) private _numOfSubmittedClaims;
 
     /// @param epochLength The epoch length
     /// @dev Reverts if the epoch length is zero.
@@ -71,13 +73,23 @@ abstract contract AbstractConsensus is IConsensus, ERC165, ApplicationChecker {
     }
 
     /// @inheritdoc IConsensus
-    function getNumberOfAcceptedClaims() external view override returns (uint256) {
-        return _numOfAcceptedClaims;
+    function getNumberOfAcceptedClaims(address appContract)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return _numOfAcceptedClaims[appContract];
     }
 
     /// @inheritdoc IConsensus
-    function getNumberOfSubmittedClaims() external view override returns (uint256) {
-        return _numOfSubmittedClaims;
+    function getNumberOfSubmittedClaims(address appContract)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return _numOfSubmittedClaims[appContract];
     }
 
     /// @inheritdoc ERC165
@@ -134,7 +146,7 @@ abstract contract AbstractConsensus is IConsensus, ERC165, ApplicationChecker {
             outputsMerkleRoot,
             machineMerkleRoot
         );
-        ++_numOfSubmittedClaims;
+        ++_numOfSubmittedClaims[appContract];
     }
 
     /// @notice Accept a claim.
@@ -160,7 +172,7 @@ abstract contract AbstractConsensus is IConsensus, ERC165, ApplicationChecker {
         emit ClaimAccepted(
             appContract, lastProcessedBlockNumber, outputsMerkleRoot, machineMerkleRoot
         );
-        ++_numOfAcceptedClaims;
+        ++_numOfAcceptedClaims[appContract];
     }
 
     /// @notice Compute the machine Merkle root given an outputs Merkle root and a proof.

--- a/src/consensus/IConsensus.sol
+++ b/src/consensus/IConsensus.sol
@@ -94,9 +94,19 @@ interface IConsensus is IOutputsMerkleRootValidator, IApplicationChecker {
     /// the integer division of the block number by the epoch length.
     function getEpochLength() external view returns (uint256);
 
-    /// @notice Get the number of claims accepted by the consensus.
-    function getNumberOfAcceptedClaims() external view returns (uint256);
+    /// @notice Get the number of claims accepted by the consensus
+    /// regarding a specific app.
+    /// @param appContract The application contract address
+    function getNumberOfAcceptedClaims(address appContract)
+        external
+        view
+        returns (uint256);
 
-    /// @notice Get the number of claims submitted to the consensus.
-    function getNumberOfSubmittedClaims() external view returns (uint256);
+    /// @notice Get the number of claims submitted to the consensus
+    /// regarding a specific app.
+    /// @param appContract The application contract address
+    function getNumberOfSubmittedClaims(address appContract)
+        external
+        view
+        returns (uint256);
 }

--- a/test/consensus/authority/AuthorityFactory.t.sol
+++ b/test/consensus/authority/AuthorityFactory.t.sol
@@ -16,6 +16,7 @@ import {IAuthorityFactory} from "src/consensus/authority/IAuthorityFactory.sol";
 import {Claim} from "../../util/Claim.sol";
 import {ConsensusTestUtils} from "../../util/ConsensusTestUtils.sol";
 import {ERC165Test} from "../../util/ERC165Test.sol";
+import {LibAddressArray} from "../../util/LibAddressArray.sol";
 import {LibBytes} from "../../util/LibBytes.sol";
 import {LibClaim} from "../../util/LibClaim.sol";
 import {LibConsensus} from "../../util/LibConsensus.sol";
@@ -26,6 +27,7 @@ import {OwnableTest} from "../../util/OwnableTest.sol";
 contract AuthorityFactoryTest is Test, ERC165Test, OwnableTest, ConsensusTestUtils {
     using LibUint256Array for uint256[];
     using LibConsensus for IAuthority;
+    using LibAddressArray for Vm;
     using LibTopic for address;
     using LibClaim for Claim;
     using LibBytes for bytes;
@@ -381,6 +383,9 @@ contract AuthorityFactoryTest is Test, ERC165Test, OwnableTest, ConsensusTestUti
 
         claim.appContract = _newActiveAppMock();
 
+        address[] memory appContractSingleton = new address[](1);
+        appContractSingleton[0] = claim.appContract;
+
         uint256[] memory blockNumbers = _randomEpochFinalBlockNumbers(epochLength);
 
         {
@@ -398,8 +403,10 @@ contract AuthorityFactoryTest is Test, ERC165Test, OwnableTest, ConsensusTestUti
 
             bytes32 machineMerkleRoot = claim.computeMachineMerkleRoot();
 
-            uint256 totalNumOfSubmittedClaims = authority.getNumberOfSubmittedClaims();
-            uint256 totalNumOfAcceptedClaims = authority.getNumberOfAcceptedClaims();
+            uint256 totalNumOfSubmittedClaims =
+                authority.getNumberOfSubmittedClaims(claim.appContract);
+            uint256 totalNumOfAcceptedClaims =
+                authority.getNumberOfAcceptedClaims(claim.appContract);
 
             vm.recordLogs();
 
@@ -467,15 +474,29 @@ contract AuthorityFactoryTest is Test, ERC165Test, OwnableTest, ConsensusTestUti
             }
 
             assertEq(
-                authority.getNumberOfSubmittedClaims(),
+                authority.getNumberOfSubmittedClaims(claim.appContract),
                 totalNumOfSubmittedClaims + 1,
                 "Total number of submitted claims should be increased by number of events"
             );
 
             assertEq(
-                authority.getNumberOfAcceptedClaims(),
+                authority.getNumberOfAcceptedClaims(claim.appContract),
                 totalNumOfAcceptedClaims + 1,
                 "Total number of accepted claims should be increased by number of events"
+            );
+
+            address notAppContract = vm.randomAddressNotIn(appContractSingleton);
+
+            assertEq(
+                authority.getNumberOfSubmittedClaims(notAppContract),
+                0,
+                "Total number of submitted claims should be zero for other apps"
+            );
+
+            assertEq(
+                authority.getNumberOfAcceptedClaims(notAppContract),
+                0,
+                "Total number of submitted claims should be zero for other apps"
             );
 
             {
@@ -495,10 +516,21 @@ contract AuthorityFactoryTest is Test, ERC165Test, OwnableTest, ConsensusTestUti
                 "Once a claim is accepted, the outputs Merkle root is valid"
             );
 
+            assertFalse(
+                authority.isOutputsMerkleRootValid(notAppContract, _randomBytes32()),
+                "Valid output Merkle roots for other apps should remain the same"
+            );
+
             assertEq(
                 authority.getLastFinalizedMachineMerkleRoot(claim.appContract),
                 lastFinalizedMachineMerkleRoot,
                 "Check last finalized machine Merkle root"
+            );
+
+            assertEq(
+                authority.getLastFinalizedMachineMerkleRoot(notAppContract),
+                bytes32(0),
+                "Last finalized machine Merkle root for other apps should remain the same"
             );
         }
     }
@@ -564,14 +596,14 @@ contract AuthorityFactoryTest is Test, ERC165Test, OwnableTest, ConsensusTestUti
 
         // Also, initially, no `ClaimSubmitted` or `ClaimAccepted` were emitted.
         assertEq(
-            authority.getNumberOfSubmittedClaims(),
+            authority.getNumberOfSubmittedClaims(vm.randomAddress()),
             0,
-            "initially, getNumberOfSubmittedClaims() == 0"
+            "initially, getNumberOfSubmittedClaims(...) == 0"
         );
         assertEq(
-            authority.getNumberOfAcceptedClaims(),
+            authority.getNumberOfAcceptedClaims(vm.randomAddress()),
             0,
-            "initially, getNumberOfAcceptedClaims() == 0"
+            "initially, getNumberOfAcceptedClaims(...) == 0"
         );
 
         // Test ERC-165 interface

--- a/test/consensus/quorum/QuorumFactory.t.sol
+++ b/test/consensus/quorum/QuorumFactory.t.sol
@@ -309,6 +309,9 @@ contract QuorumFactoryTest is Test, ERC165Test, ConsensusTestUtils {
 
         address appContract = _newActiveAppMock();
 
+        address[] memory appContractSingleton = new address[](1);
+        appContractSingleton[0] = appContract;
+
         uint256[] memory blockNumbers = _randomEpochFinalBlockNumbers(epochLength);
 
         {
@@ -455,9 +458,9 @@ contract QuorumFactoryTest is Test, ERC165Test, ConsensusTestUtils {
                 }
 
                 uint256 totalNumOfSubmittedClaimsBefore =
-                    quorum.getNumberOfSubmittedClaims();
+                    quorum.getNumberOfSubmittedClaims(appContract);
                 uint256 totalNumOfAcceptedClaimsBefore =
-                    quorum.getNumberOfAcceptedClaims();
+                    quorum.getNumberOfAcceptedClaims(appContract);
 
                 uint256 numOfValidatorsInFavorOfAnyClaimInEpochBefore =
                     quorum.numOfValidatorsInFavorOfAnyClaimInEpoch(
@@ -604,15 +607,29 @@ contract QuorumFactoryTest is Test, ERC165Test, ConsensusTestUtils {
                 );
 
                 assertEq(
-                    quorum.getNumberOfSubmittedClaims(),
+                    quorum.getNumberOfSubmittedClaims(appContract),
                     totalNumOfSubmittedClaimsBefore + numOfClaimSubmittedEvents,
                     "Total number of submitted claims should be increased by number of events"
                 );
 
                 assertEq(
-                    quorum.getNumberOfAcceptedClaims(),
+                    quorum.getNumberOfAcceptedClaims(appContract),
                     totalNumOfAcceptedClaimsBefore + numOfClaimAcceptedEvents,
                     "Total number of accepted claims should be increased by number of events"
+                );
+
+                address notAppContract = vm.randomAddressNotIn(appContractSingleton);
+
+                assertEq(
+                    quorum.getNumberOfSubmittedClaims(notAppContract),
+                    0,
+                    "Total number of submitted claims should be zero for other apps"
+                );
+
+                assertEq(
+                    quorum.getNumberOfAcceptedClaims(notAppContract),
+                    0,
+                    "Total number of submitted claims should be zero for other apps"
                 );
 
                 assertEq(
@@ -623,11 +640,26 @@ contract QuorumFactoryTest is Test, ERC165Test, ConsensusTestUtils {
                     "Number of validators in favor of any claim in epoch should be incremented"
                 );
 
+                assertEq(
+                    quorum.numOfValidatorsInFavorOfAnyClaimInEpoch(
+                        notAppContract, lastProcessedBlockNumber
+                    ),
+                    0,
+                    "Number of validators in favor of any claim in epoch should be zero for other apps"
+                );
+
                 assertTrue(
                     quorum.isValidatorInFavorOfAnyClaimInEpoch(
                         appContract, lastProcessedBlockNumber, id
                     ),
                     "Expected validator to be in favor of any claim in epoch"
+                );
+
+                assertFalse(
+                    quorum.isValidatorInFavorOfAnyClaimInEpoch(
+                        notAppContract, lastProcessedBlockNumber, id
+                    ),
+                    "Validator shouldn't be in favor of any claim in epoch for other apps"
                 );
 
                 assertEq(
@@ -638,11 +670,19 @@ contract QuorumFactoryTest is Test, ERC165Test, ConsensusTestUtils {
                     "Number of validators in favor of claim should be incremented"
                 );
 
-                assertTrue(
-                    quorum.isValidatorInFavorOf(
-                        appContract, lastProcessedBlockNumber, machineMerkleRoot, id
+                assertEq(
+                    quorum.numOfValidatorsInFavorOf(
+                        notAppContract, lastProcessedBlockNumber, machineMerkleRoot
                     ),
-                    "Expected validator to be in favor of claim"
+                    0,
+                    "Number of validators in favor of claim should be zero for other apps"
+                );
+
+                assertFalse(
+                    quorum.isValidatorInFavorOf(
+                        notAppContract, lastProcessedBlockNumber, machineMerkleRoot, id
+                    ),
+                    "Validator shouldn't be in favor of claim for other apps"
                 );
 
                 vm.recordLogs();
@@ -854,14 +894,14 @@ contract QuorumFactoryTest is Test, ERC165Test, ConsensusTestUtils {
 
         // Also, initially, no `ClaimSubmitted` or `ClaimAccepted` were emitted.
         assertEq(
-            quorum.getNumberOfSubmittedClaims(),
+            quorum.getNumberOfSubmittedClaims(vm.randomAddress()),
             0,
-            "initially, getNumberOfSubmittedClaims() == 0"
+            "initially, getNumberOfSubmittedClaims(...) == 0"
         );
         assertEq(
-            quorum.getNumberOfAcceptedClaims(),
+            quorum.getNumberOfAcceptedClaims(vm.randomAddress()),
             0,
-            "initially, getNumberOfAcceptedClaims() == 0"
+            "initially, getNumberOfAcceptedClaims(...) == 0"
         );
 
         // Test ERC-165 interface


### PR DESCRIPTION
@mpolitzer I couldn't apply your patch directly because of changes incurred by #485 being merged onto `next/3.0`. But, as you will see in the diff, most changes are pretty much what you've implemented in your patch, plus tests.

Closes #491.