### PR TITLE
Smaller account validity proof

### DIFF
--- a/.changeset/brown-schools-prove.md
+++ b/.changeset/brown-schools-prove.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": major
+---
+
+Remove `InvalidAccountIndex` (in favor of already-existing `InvalidNodeIndex` error)

--- a/.changeset/icy-pandas-build.md
+++ b/.changeset/icy-pandas-build.md
@@ -1,0 +1,7 @@
+---
+"@cartesi/rollups": major
+---
+
+Reduce account validity proof size by splitting the validation process into two:
+- First, the accounts drive Merkle root is validated through the new `proveAccountsDriveMerkleRoot` function
+- Second, the account is validated based on the proved accounts drive Merkle root

--- a/.changeset/lazy-pugs-sit.md
+++ b/.changeset/lazy-pugs-sit.md
@@ -1,0 +1,12 @@
+---
+"@cartesi/rollups": minor
+---
+
+Add new definitions to `IApplicationWithdrawal` interface:
+
+- `getAccountsDriveMerkleRoot` view function: checks whether the accounts drive Merkle root was proved, and its value
+- `proveAccountsDriveMerkleRoot` function: proves the accounts drive Merkle root based on the last-finalized machine Merkle root
+- `InvalidAccountsDriveMerkleRootProofSize` error: raised when accounts drive Merkle root proof size is invalid
+- `AccountsDriveMerkleRootAlreadyProved` error: raised when trying to prove accounts drive Merkle root after it has already been proved
+- `AccountsDriveMerkleRootNotProved` error: raised when trying to validate account before accounts drive Merkle root has been proved
+- `InvalidAccountsDriveMerkleRoot` error: raised when account validity proof produces accounts drive Merkle root different from proved one

--- a/src/dapp/Application.sol
+++ b/src/dapp/Application.sol
@@ -44,6 +44,7 @@ contract Application is
     using LibAccountValidityProof for AccountValidityProof;
     using LibAddress for address;
     using LibBinaryMerkleTree for bytes;
+    using LibBinaryMerkleTree for bytes32[];
     using LibBytes for bytes;
     using LibOutputValidityProof for OutputValidityProof;
     using LibWithdrawalConfig for WithdrawalConfig;
@@ -94,6 +95,16 @@ contract Application is
     /// @notice Whether the application has been foreclosed by the guardian.
     /// @dev See the `isForeclosed` function.
     bool internal _isForeclosed;
+
+    /// @notice Whether the accounts drive Merkle root was proved.
+    /// @dev See the `getAccountsDriveMerkleRoot` and
+    /// `proveAccountsDriveMerkleRoot` functions.
+    bool internal _wasAccountsDriveMerkleRootProved;
+
+    /// @notice The accounts drive Merkle root.
+    /// @dev See the `getAccountsDriveMerkleRoot` and
+    /// `proveAccountsDriveMerkleRoot` functions.
+    bytes32 internal _accountsDriveMerkleRoot;
 
     /// @notice The number of outputs executed by the application.
     /// @dev See the `getNumberOfExecutedOutputs` function.
@@ -156,6 +167,44 @@ contract Application is
 
         ++_numOfExecutedOutputs;
         emit OutputExecuted(outputIndex, output);
+    }
+
+    function proveAccountsDriveMerkleRoot(
+        bytes32 accountsDriveMerkleRoot,
+        bytes32[] calldata proof
+    ) external override onlyForeclosed {
+        if (_wasAccountsDriveMerkleRootProved) {
+            revert AccountsDriveMerkleRootAlreadyProved();
+        }
+
+        if (
+            proof.length
+                != (CanonicalMachine.LOG2_MEMORY_SIZE - _getLog2AccountsDriveSize())
+        ) {
+            revert InvalidAccountsDriveMerkleRootProofSize();
+        }
+
+        // The Merkle root computation below should not raise an InvalidNodeIndex error
+        // because the LibWithdrawalConfig.isValid function run at the constructor
+        // guarantees that
+        // getAccountsDriveStartIndex() >> proof.length == 0.
+
+        bytes32 machineMerkleRoot = proof.merkleRootAfterReplacement(
+            getAccountsDriveStartIndex(), accountsDriveMerkleRoot, LibKeccak256.hashPair
+        );
+
+        // There is no risk of reentrancy attacks when retrieving the last-finalized
+        // machine Merkle root from the outputs Merkle root validator because it is done
+        // through a static call, which reverts on any state change.
+
+        bytes32 lastFinalizedMachineMerkleRoot = _getLastFinalizedMachineMerkleRoot();
+
+        if (machineMerkleRoot != lastFinalizedMachineMerkleRoot) {
+            revert InvalidMachineMerkleRoot(machineMerkleRoot);
+        }
+
+        _accountsDriveMerkleRoot = accountsDriveMerkleRoot;
+        _wasAccountsDriveMerkleRootProved = true;
     }
 
     function withdraw(bytes calldata account, AccountValidityProof calldata proof)
@@ -260,22 +309,19 @@ contract Application is
         bytes32 accountMerkleRoot,
         AccountValidityProof calldata proof
     ) public view override {
-        if (!proof.isSiblingsArrayLengthValid(getLog2LeavesPerAccount())) {
+        if (!proof.isSiblingsArrayLengthValid(getLog2MaxNumOfAccounts())) {
             revert InvalidAccountRootSiblingsArrayLength();
         }
 
-        if (!proof.isAccountIndexValid(getLog2MaxNumOfAccounts())) {
-            revert InvalidAccountIndex();
+        if (!_wasAccountsDriveMerkleRootProved) {
+            revert AccountsDriveMerkleRootNotProved();
         }
 
-        bytes32 machineMerkleRoot = proof.computeMachineMerkleRoot(
-            accountMerkleRoot, getLog2MaxNumOfAccounts(), getAccountsDriveStartIndex()
-        );
+        bytes32 accountsDriveMerkleRoot =
+            proof.computeAccountsDriveMerkleRoot(accountMerkleRoot);
 
-        bytes32 lastFinalizedMachineMerkleRoot = _getLastFinalizedMachineMerkleRoot();
-
-        if (machineMerkleRoot != lastFinalizedMachineMerkleRoot) {
-            revert InvalidMachineMerkleRoot(machineMerkleRoot);
+        if (accountsDriveMerkleRoot != _accountsDriveMerkleRoot) {
+            revert InvalidAccountsDriveMerkleRoot(accountsDriveMerkleRoot);
         }
     }
 
@@ -342,6 +388,16 @@ contract Application is
         return _isForeclosed;
     }
 
+    function getAccountsDriveMerkleRoot()
+        external
+        view
+        override
+        returns (bool wasAccountsDriveMerkleRootProved, bytes32 accountsDriveMerkleRoot)
+    {
+        wasAccountsDriveMerkleRootProved = _wasAccountsDriveMerkleRootProved;
+        accountsDriveMerkleRoot = _accountsDriveMerkleRoot;
+    }
+
     /// @inheritdoc Ownable
     function owner() public view override(IOwnable, Ownable) returns (address) {
         return super.owner();
@@ -365,6 +421,13 @@ contract Application is
     modifier onlyForeclosed() {
         _ensureAppIsForeclosed();
         _;
+    }
+
+    /// @notice Get the log (base 2) of the number of bytes in the machine memory that are
+    /// reserved for the accounts drive.
+    function _getLog2AccountsDriveSize() internal view returns (uint8) {
+        return getLog2MaxNumOfAccounts() + getLog2LeavesPerAccount()
+            + CanonicalMachine.LOG2_DATA_BLOCK_SIZE;
     }
 
     /// @notice Check if an outputs Merkle root is valid,

--- a/src/dapp/IApplicationWithdrawal.sol
+++ b/src/dapp/IApplicationWithdrawal.sol
@@ -19,30 +19,46 @@ interface IApplicationWithdrawal is
     /// @notice MUST trigger when the funds of an account are withdrawn.
     /// @param accountIndex The account index in the accounts drive
     /// @param account The account as encoded in the accounts drive
-    /// @param account The withdrawal output
+    /// @param output The withdrawal output
     event Withdrawal(uint64 accountIndex, bytes account, bytes output);
 
     // Errors
 
     /// @notice Raised when the application has not yet been foreclosed
-    /// and therefore withdrawals cannot yet be performed.
+    /// and therefore withdrawal-related actions cannot be performed yet.
     error NotForeclosed();
 
+    /// @notice Raised when the accounts drive Merkle root proof size is invalid.
+    /// @dev The array length should be log2 of the machine memory size - log2 of the
+    /// accounts drive size. See the `CanonicalMachine` library and the
+    /// `getLog2MaxNumOfAccounts` and `getLog2LeavesPerAccount` functions.
+    error InvalidAccountsDriveMerkleRootProofSize();
+
+    /// @notice Raised when someone tries to prove the accounts drive Merkle root but it
+    /// has already been proved. This error adds an extra layer of protection against
+    /// consensus-takeover attacks in which `getLastFinalizedMachineMerkleRoot` returns
+    /// a different value after the application is foreclosed.
+    error AccountsDriveMerkleRootAlreadyProved();
+
+    /// @notice Raised when someone tries to validate an accounts Merkle root but the
+    /// accounts drive Merkle root has not yet been proved through the
+    /// `proveAccountsDriveMerkleRoot` function.
+    error AccountsDriveMerkleRootNotProved();
+
     /// @notice Raised when the account root siblings array has an invalid length.
-    /// @dev The array length should be log2 of the machine memory size -
-    /// log2 of the data block size - log2 of the maximum number of accounts.
-    /// See the `CanonicalMachine` library for machine constants
-    /// and the `getLog2MaxNumOfAccounts` function for accounts drive parameters.
+    /// @dev The array length should be log2 of the maximum number of accounts. See the
+    /// `getLog2MaxNumOfAccounts` function.
     error InvalidAccountRootSiblingsArrayLength();
 
-    /// @notice Raised when the account index is outside the accounts drive boundaries.
-    /// See the `getLog2MaxNumOfAccounts` for accounts drive parameters.
-    error InvalidAccountIndex();
-
-    /// @notice Raised when the computed machine Merkle root differs
-    /// from the one provided by the current outputs Merkle root validator.
+    /// @notice Raised when the computed machine Merkle root differs from the
+    /// last-finalized machine Merkle root provided by the outputs Merkle root validator.
     /// @param machineMerkleRoot The computed machine Merkle root
     error InvalidMachineMerkleRoot(bytes32 machineMerkleRoot);
+
+    /// @notice Raised when the computed accounts drive Merkle root differs
+    /// from the one proved through the `proveAccountsDriveMerkleRoot` function.
+    /// @param accountsDriveMerkleRoot The computed accounts drive Merkle root
+    error InvalidAccountsDriveMerkleRoot(bytes32 accountsDriveMerkleRoot);
 
     /// @notice Raised when trying to withdraw funds of an account
     /// whose funds have already been withdrawn.
@@ -51,8 +67,22 @@ interface IApplicationWithdrawal is
 
     // Write functions
 
+    /// @notice Prove the accounts drive Merkle root in the last-finalized machine state
+    /// provided by the application's outputs Merkle root validator. This function can be
+    /// called by anyone after the app is foreclosed so that accounts can be validated and
+    /// their funds can be withdrawn.
+    /// @param accountsDriveMerkleRoot The accounts drive Merkle root
+    /// @param proof Siblings of the accounts drive Merkle root in the machine
+    /// @dev May raise `NotForeclosed`, `AccountsDriveMerkleRootAlreadyProved`,
+    /// `InvalidAccountsDriveMerkleRootProofSize` or `InvalidMachineMerkleRoot`.
+    /// On success, stores the proved accounts drive Merkle root.
+    function proveAccountsDriveMerkleRoot(
+        bytes32 accountsDriveMerkleRoot,
+        bytes32[] calldata proof
+    ) external;
+
     /// @notice Withdraw the funds of an account from the foreclosed application.
-    /// First, the account is validated against the last finalized machine Merkle root.
+    /// First, the account is validated against the proved accounts drive Merkle root.
     /// Then, a withdrawal output is built from the account, and executed.
     /// @param account The account
     /// @param proof The proof used to validate the account
@@ -63,6 +93,14 @@ interface IApplicationWithdrawal is
         external;
 
     // View Functions
+
+    /// @notice Check whether the accounts drive Merkle root was proved and its value.
+    /// @return wasAccountsDriveMerkleRootProved Whether the accounts drive Merkle root was proved
+    /// @return accountsDriveMerkleRoot The accounts drive Merkle root (if proved)
+    function getAccountsDriveMerkleRoot()
+        external
+        view
+        returns (bool wasAccountsDriveMerkleRootProved, bytes32 accountsDriveMerkleRoot);
 
     /// @notice Get the number of withdrawals.
     /// Useful for fast-syncing `Withdrawal` events.
@@ -83,14 +121,11 @@ interface IApplicationWithdrawal is
     /// drive tree whose leaves are the account roots.
     function getLog2MaxNumOfAccounts() external view returns (uint8);
 
-    /// @notice Get the factor that, when multiplied by the
-    /// size of the accounts drive, yields the start memory address
-    /// of the accounts drive.
-    /// @dev If `a = getLog2LeavesPerAccount()`
-    /// `b = getLog2MaxNumOfAccounts()`,
-    /// and `c = getAccountsDriveStartIndex()`,
-    /// then the accounts drive starts at `c*2^{a+b+5}`
-    /// and has size `2^{a+b+5}`.
+    /// @notice Get the factor that, when multiplied by the size of the accounts
+    /// drive, yields the start memory address of the accounts drive.
+    /// @dev If `a = getLog2LeavesPerAccount()` `b = getLog2MaxNumOfAccounts()`,
+    /// and `c = getAccountsDriveStartIndex()`, then the accounts drive starts
+    /// at memory address `c*2^{a+b+5}` and has `2^{a+b+5}` bytes in size.
     function getAccountsDriveStartIndex() external view returns (uint64);
 
     /// @notice Get the withdrawal output builder, which gets static-called
@@ -99,23 +134,25 @@ interface IApplicationWithdrawal is
 
     /// @notice Validate the existence of an account at a given index
     /// on the accounts drive given a Merkle proof of the account root,
-    /// according to the last finalized machine Merkle root reported by
-    /// the application outputs Merkle root validator.
+    /// according to the accounts drive Merkle root proved through the
+    /// `proveAccountsDriveMerkleRoot` function.
     /// @param account The account
     /// @param proof The proof used to validate the account
-    /// @dev May raise any of the errors raised by `validateAccountMerkleRoot`.
+    /// @dev May raise any of the errors raised by `validateAccountMerkleRoot`,
+    /// as well as `DriveSmallerThanData` (if the provided account is too large).
     function validateAccount(bytes calldata account, AccountValidityProof calldata proof)
         external
         view;
 
     /// @notice Validate the existence of an account at a given index
     /// on the accounts drive given a Merkle proof of the account root,
-    /// according to the last finalized machine Merkle root reported by
-    /// the application outputs Merkle root validator.
+    /// according to the accounts drive Merkle root proved through the
+    /// `proveAccountsDriveMerkleRoot` function.
     /// @param accountMerkleRoot The account Merkle root
     /// @param proof The proof used to validate the account
-    /// @dev May raise `InvalidAccountRootSiblingsArrayLength`,
-    /// `InvalidAccountIndex`, or `InvalidMachineMerkleRoot`.
+    /// @dev May raise `InvalidAccountRootSiblingsArrayLength`, `InvalidNodeIndex`
+    /// (if the account index is outside the boundaries of the accounts drive),
+    /// `AccountsDriveMerkleRootNotProved` or `InvalidAccountsDriveMerkleRoot`.
     function validateAccountMerkleRoot(
         bytes32 accountMerkleRoot,
         AccountValidityProof calldata proof

--- a/src/library/LibAccountValidityProof.sol
+++ b/src/library/LibAccountValidityProof.sol
@@ -4,51 +4,25 @@
 pragma solidity ^0.8.8;
 
 import {AccountValidityProof} from "../common/AccountValidityProof.sol";
-import {CanonicalMachine} from "../common/CanonicalMachine.sol";
 import {LibBinaryMerkleTree} from "./LibBinaryMerkleTree.sol";
 import {LibKeccak256} from "./LibKeccak256.sol";
 
 library LibAccountValidityProof {
     function isSiblingsArrayLengthValid(
         AccountValidityProof calldata v,
-        uint8 log2LeavesPerAccount
-    ) internal pure returns (bool) {
-        // The addition below cannot overflow because
-        /// `ceil(calldatasize / 32) + 2 * type(uint8).max <= type(uint256).max`.
-        // (Considering the cost of tx calldata size, the tx gas cost would likely
-        /// surpass the block gas limit.)
-        return (v.accountRootSiblings.length + CanonicalMachine.LOG2_DATA_BLOCK_SIZE
-                    + log2LeavesPerAccount) == CanonicalMachine.LOG2_MEMORY_SIZE;
-    }
-
-    function isAccountIndexValid(
-        AccountValidityProof calldata v,
         uint8 log2MaxNumOfAccounts
     ) internal pure returns (bool) {
-        // This is equivalent to `accountIndex < 2^{log2MaxNumOfAccounts}`,
-        // and works with any value of `log2MaxNumOfAccounts`, even if
-        // typed as `uint256`.
-        return (v.accountIndex >> log2MaxNumOfAccounts) == 0;
+        return v.accountRootSiblings.length == log2MaxNumOfAccounts;
     }
 
-    function computeMachineMerkleRoot(
+    function computeAccountsDriveMerkleRoot(
         AccountValidityProof calldata v,
-        bytes32 accountMerkleRoot,
-        uint8 log2MaxNumOfAccounts,
-        uint64 accountsDriveStartIndex
+        bytes32 accountMerkleRoot
     ) internal pure returns (bytes32) {
-        bytes32 accountsDriveMerkleRoot =
-            LibBinaryMerkleTree.merkleRootAfterReplacement(
-                v.accountRootSiblings[:log2MaxNumOfAccounts],
-                v.accountIndex,
-                accountMerkleRoot,
-                LibKeccak256.hashPair
-            );
-
         return LibBinaryMerkleTree.merkleRootAfterReplacement(
-            v.accountRootSiblings[log2MaxNumOfAccounts:],
-            accountsDriveStartIndex,
-            accountsDriveMerkleRoot,
+            v.accountRootSiblings,
+            v.accountIndex,
+            accountMerkleRoot,
             LibKeccak256.hashPair
         );
     }

--- a/test/dapp/Application.t.sol
+++ b/test/dapp/Application.t.sol
@@ -190,6 +190,9 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
         vm.prank(_appContract.getGuardian());
         _appContract.foreclose();
         _validateOutputs();
+
+        _proveAccountsDriveMerkleRoot();
+        _validateOutputs();
     }
 
     function testRevertsInvalidOutputHashesSiblingsArrayLength(bytes32[] calldata invalidOutputHashesSiblings)
@@ -260,22 +263,23 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
         _appContract.validateOutputHash(outputHash, proof);
     }
 
-    function testRevertsInvalidNodeIndex(uint256) external {
+    function testValidateOutputRevertsInvalidNodeIndex(uint256) external {
         string memory name = _getRandomOutputName();
         bytes memory output = _getOutput(name);
         OutputValidityProof memory proof = _getOutputValidityProof(name);
 
-        uint256 invalidOutputIndex =
-            vm.randomUint(1 << CanonicalMachine.LOG2_MAX_OUTPUTS, type(uint64).max);
+        uint256 log2MaxNumOfOutputs = CanonicalMachine.LOG2_MAX_OUTPUTS;
+        uint256 maxNumOfOutputs = 1 << log2MaxNumOfOutputs;
+        uint256 invalidOutputIndex = vm.randomUint(maxNumOfOutputs, type(uint64).max);
 
         assertNotEq(invalidOutputIndex, proof.outputIndex);
 
         proof.outputIndex = invalidOutputIndex.toUint64();
 
-        vm.expectRevert(_encodeInvalidNodeIndex(invalidOutputIndex));
+        vm.expectRevert(_encodeInvalidNodeIndex(invalidOutputIndex, log2MaxNumOfOutputs));
         _appContract.validateOutput(output, proof);
 
-        vm.expectRevert(_encodeInvalidNodeIndex(invalidOutputIndex));
+        vm.expectRevert(_encodeInvalidNodeIndex(invalidOutputIndex, log2MaxNumOfOutputs));
         _appContract.validateOutputHash(keccak256(output), proof);
     }
 
@@ -394,17 +398,99 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
         _testErc20Success(output, proof);
     }
 
+    // ----------------------------------
+    // accounts drive Merkle root proving
+    // ----------------------------------
+
+    function testRevertsInvalidAccountsDriveMerkleRootProofSize(bytes32[] calldata invalidProof)
+        external
+    {
+        // We assume the proof provided by the emulator library has the correct length,
+        // and that the proof provided by the fuzzer has a different, incorrect length.
+        vm.assume(invalidProof.length != _getAccountsDriveMerkleRootProof().length);
+
+        vm.prank(_appContract.getGuardian());
+        _appContract.foreclose();
+
+        bytes32 accountsDriveMerkleRoot = _getAccountsDriveMerkleRoot();
+
+        vm.expectRevert(_encodeInvalidAccountsDriveMerkleRootProofSize());
+        vm.prank(vm.randomAddress());
+        _appContract.proveAccountsDriveMerkleRoot(accountsDriveMerkleRoot, invalidProof);
+    }
+
+    function testRevertsInvalidMachineMerkleRoot(bytes32 invalidAccountsDriveMerkleRoot)
+        external
+    {
+        vm.assume(invalidAccountsDriveMerkleRoot != _getAccountsDriveMerkleRoot());
+
+        vm.prank(_appContract.getGuardian());
+        _appContract.foreclose();
+
+        bytes32[] memory proof = _getAccountsDriveMerkleRootProof();
+
+        bytes32 invalidMachineMerkleRoot = proof.merkleRootAfterReplacement(
+            LibEmulator.ACCOUNTS_DRIVE_START_INDEX, invalidAccountsDriveMerkleRoot
+        );
+
+        vm.expectRevert(_encodeInvalidMachineMerkleRoot(invalidMachineMerkleRoot));
+        vm.prank(vm.randomAddress());
+        _appContract.proveAccountsDriveMerkleRoot(invalidAccountsDriveMerkleRoot, proof);
+    }
+
+    function testProveAccountsDriveMerkleRoot() external {
+        bytes32 accountsDriveMerkleRoot = _getAccountsDriveMerkleRoot();
+        bytes32[] memory proof = _getAccountsDriveMerkleRootProof();
+
+        vm.expectRevert(IApplicationWithdrawal.NotForeclosed.selector);
+        vm.prank(vm.randomAddress());
+        _appContract.proveAccountsDriveMerkleRoot(accountsDriveMerkleRoot, proof);
+
+        {
+            bool wasValueProved;
+            (wasValueProved,) = _appContract.getAccountsDriveMerkleRoot();
+            assertFalse(wasValueProved);
+        }
+
+        vm.prank(_appContract.getGuardian());
+        _appContract.foreclose();
+
+        {
+            bool wasValueProved;
+            (wasValueProved,) = _appContract.getAccountsDriveMerkleRoot();
+            assertFalse(wasValueProved);
+        }
+
+        vm.prank(vm.randomAddress());
+        _appContract.proveAccountsDriveMerkleRoot(accountsDriveMerkleRoot, proof);
+
+        {
+            bool wasValueProved;
+            bytes32 value;
+            (wasValueProved, value) = _appContract.getAccountsDriveMerkleRoot();
+            assertTrue(wasValueProved);
+            assertEq(value, accountsDriveMerkleRoot);
+        }
+
+        vm.expectRevert(_encodeAccountsDriveMerkleRootAlreadyProved());
+        vm.prank(vm.randomAddress());
+        _appContract.proveAccountsDriveMerkleRoot(accountsDriveMerkleRoot, proof);
+    }
+
     // ------------------
     // account validation
     // ------------------
 
-    function testValidateAccounts() external view {
-        _validateAccounts();
+    function testValidateAccounts() external {
+        _validateAccounts(_encodeAccountsDriveMerkleRootNotProved());
     }
 
     function testValidateAccountsAfterForeclosure() external {
         vm.prank(_appContract.getGuardian());
         _appContract.foreclose();
+        _validateAccounts(_encodeAccountsDriveMerkleRootNotProved());
+
+        _proveAccountsDriveMerkleRoot();
         _validateAccounts();
     }
 
@@ -429,30 +515,39 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
         _appContract.validateAccountMerkleRoot(accountMerkleRoot, proof);
     }
 
-    function testRevertsInvalidAccountIndex(uint256) external {
+    function testValidateAccountRevertsInvalidNodeIndex(uint256) external {
         string memory name = _getRandomAccountName();
         bytes memory account = _getAccount(name);
         bytes32 accountMerkleRoot = LibEmulator.getAccountMerkleRoot(account);
         AccountValidityProof memory proof = _getAccountValidityProof(name);
 
-        uint256 numOfAccounts = 1 << LibEmulator.getAccountsDriveRootNodeHeight();
-        uint256 invalidAccountIndex = vm.randomUint(numOfAccounts, type(uint64).max);
+        uint256 log2MaxNumOfAccounts = LibEmulator.LOG2_MAX_NUM_OF_ACCOUNTS;
+        uint256 maxNumOfAccounts = 1 << log2MaxNumOfAccounts;
+        uint256 invalidAccountIndex = vm.randomUint(maxNumOfAccounts, type(uint64).max);
 
         assertNotEq(invalidAccountIndex, proof.accountIndex);
 
         proof.accountIndex = invalidAccountIndex.toUint64();
 
-        vm.expectRevert(_encodeInvalidAccountIndex());
+        vm.prank(_appContract.getGuardian());
+        _appContract.foreclose();
+        _proveAccountsDriveMerkleRoot();
+
+        vm.expectRevert(_encodeInvalidNodeIndex(proof.accountIndex, log2MaxNumOfAccounts));
         _appContract.validateAccount(account, proof);
 
-        vm.expectRevert(_encodeInvalidAccountIndex());
+        vm.expectRevert(_encodeInvalidNodeIndex(proof.accountIndex, log2MaxNumOfAccounts));
         _appContract.validateAccountMerkleRoot(accountMerkleRoot, proof);
     }
 
-    function testRevertsInvalidMachineMerkleRoot(uint256) external {
+    function testRevertsInvalidAccountsDriveMerkleRoot(uint256) external {
         string memory name = _getRandomAccountName();
         bytes memory account = _getAccount(name);
         AccountValidityProof memory proof = _getAccountValidityProof(name);
+
+        vm.prank(_appContract.getGuardian());
+        _appContract.foreclose();
+        _proveAccountsDriveMerkleRoot();
 
         bytes memory invalidAccount = _generateAccount();
 
@@ -463,25 +558,17 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
         // the account whose proof we will be using.
         vm.assume(LibEmulator.getAccountMerkleRoot(account) != invalidAccountMerkleRoot);
 
-        (bytes32[] memory siblings1, bytes32[] memory siblings2) =
-            proof.accountRootSiblings.split(LibEmulator.LOG2_MAX_NUM_OF_ACCOUNTS);
-
         bytes32 invalidAccountsDriveMerkleRoot =
-            ExternalLibBinaryMerkleTree.merkleRootAfterReplacement(
-                siblings1, proof.accountIndex, invalidAccountMerkleRoot
-            );
+            proof.accountRootSiblings
+                .merkleRootAfterReplacement(proof.accountIndex, invalidAccountMerkleRoot);
 
-        bytes32 invalidMachineMerkleRoot =
-            ExternalLibBinaryMerkleTree.merkleRootAfterReplacement(
-                siblings2,
-                LibEmulator.ACCOUNTS_DRIVE_START_INDEX,
-                invalidAccountsDriveMerkleRoot
-            );
+        bytes memory invalidAccountsDriveMerkleRootError =
+            _encodeInvalidAccountsDriveMerkleRoot(invalidAccountsDriveMerkleRoot);
 
-        vm.expectRevert(_encodeInvalidMachineMerkleRoot(invalidMachineMerkleRoot));
+        vm.expectRevert(invalidAccountsDriveMerkleRootError);
         _appContract.validateAccount(invalidAccount, proof);
 
-        vm.expectRevert(_encodeInvalidMachineMerkleRoot(invalidMachineMerkleRoot));
+        vm.expectRevert(invalidAccountsDriveMerkleRootError);
         _appContract.validateAccountMerkleRoot(invalidAccountMerkleRoot, proof);
     }
 
@@ -529,6 +616,7 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
 
         vm.prank(_appContract.getGuardian());
         _appContract.foreclose();
+        _proveAccountsDriveMerkleRoot();
 
         vm.expectRevert(_encodeErc20InsufficientBalance(_usd, amount));
 
@@ -553,6 +641,7 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
 
         vm.prank(_appContract.getGuardian());
         _appContract.foreclose();
+        _proveAccountsDriveMerkleRoot();
 
         vm.expectRevert(error);
 
@@ -581,6 +670,7 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
 
         vm.prank(_appContract.getGuardian());
         _appContract.foreclose();
+        _proveAccountsDriveMerkleRoot();
 
         vm.expectRevert(_encodeSafeErc20FailedOperation(address(_usd)));
 
@@ -597,6 +687,7 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
 
         vm.prank(_appContract.getGuardian());
         _appContract.foreclose();
+        _proveAccountsDriveMerkleRoot();
 
         vm.expectRevert(_encodeSafeErc20FailedOperation(address(_usd)));
 
@@ -617,6 +708,7 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
 
         vm.prank(_appContract.getGuardian());
         _appContract.foreclose();
+        _proveAccountsDriveMerkleRoot();
 
         vm.expectRevert(_encodeAccountTooShort(accountSize));
         vm.prank(vm.randomAddress());
@@ -653,6 +745,7 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
 
         vm.prank(_appContract.getGuardian());
         _appContract.foreclose();
+        _proveAccountsDriveMerkleRoot();
 
         vm.recordLogs();
 
@@ -979,14 +1072,28 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
         return vm.randomBytes(accountSize);
     }
 
+    function _getAccountsDriveMerkleRoot()
+        internal
+        view
+        returns (bytes32 accountsDriveMerkleRoot)
+    {
+        return _emulator.getAccountsDriveMerkleRoot();
+    }
+
+    function _getAccountsDriveMerkleRootProof()
+        internal
+        view
+        returns (bytes32[] memory accountsDriveMerkleRootSiblings)
+    {
+        return _proofComponents.getAccountsDriveMerkleRootProof();
+    }
+
     function _getAccountValidityProof(string memory name)
         internal
         view
         returns (AccountValidityProof memory)
     {
-        return _emulator.getAccountValidityProof(
-            _proofComponents, _accountIndexByName[name]
-        );
+        return _emulator.getAccountValidityProof(_accountIndexByName[name]);
     }
 
     /// @notice This function is used to simulate a foreclosure and a withdrawal.
@@ -1027,7 +1134,7 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
 
         // attempt to validate/withdraw accounts
         {
-            bytes memory error = _encodeInvalidMachineMerkleRoot(machineMerkleRoot);
+            bytes memory error = _encodeAccountsDriveMerkleRootNotProved();
             for (uint256 i; i < _accountNames.length; ++i) {
                 string memory name = _accountNames[i];
                 bytes memory account = _getAccount(name);
@@ -1037,6 +1144,9 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
                 _appContract.validateAccountMerkleRoot(accountMerkleRoot, proof);
                 vm.expectRevert(error);
                 _appContract.validateAccount(account, proof);
+                vm.expectRevert(IApplicationWithdrawal.NotForeclosed.selector);
+                vm.prank(vm.randomAddress());
+                _appContract.withdraw(account, proof);
                 vm.expectRevert(error);
                 this.simulateForeclosureAndWithdrawal(account, proof);
             }
@@ -1058,6 +1168,13 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
             machineMerkleRoot,
             "last finalized machine Merkle root"
         );
+    }
+
+    function _proveAccountsDriveMerkleRoot() internal {
+        bytes32 accountsDriveMerkleRoot = _getAccountsDriveMerkleRoot();
+        bytes32[] memory proof = _getAccountsDriveMerkleRootProof();
+        vm.prank(vm.randomAddress());
+        _appContract.proveAccountsDriveMerkleRoot(accountsDriveMerkleRoot, proof);
     }
 
     function _expectEmitOutputExecuted(
@@ -1110,15 +1227,13 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
         );
     }
 
-    function _encodeInvalidNodeIndex(uint256 nodeIndex)
+    function _encodeInvalidNodeIndex(uint256 nodeIndex, uint256 height)
         internal
         pure
         returns (bytes memory)
     {
         return abi.encodeWithSelector(
-            BinaryMerkleTreeErrors.InvalidNodeIndex.selector,
-            nodeIndex,
-            CanonicalMachine.LOG2_MAX_OUTPUTS
+            BinaryMerkleTreeErrors.InvalidNodeIndex.selector, nodeIndex, height
         );
     }
 
@@ -1130,8 +1245,12 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
         return IApplicationWithdrawal.InvalidAccountRootSiblingsArrayLength.selector;
     }
 
-    function _encodeInvalidAccountIndex() internal pure returns (bytes4) {
-        return IApplicationWithdrawal.InvalidAccountIndex.selector;
+    function _encodeInvalidAccountsDriveMerkleRootProofSize()
+        internal
+        pure
+        returns (bytes4)
+    {
+        return IApplicationWithdrawal.InvalidAccountsDriveMerkleRootProofSize.selector;
     }
 
     function _encodeInvalidOutputHashesSiblingsArrayLength()
@@ -1142,6 +1261,26 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
         return IApplication.InvalidOutputHashesSiblingsArrayLength.selector;
     }
 
+    function _encodeAccountsDriveMerkleRootAlreadyProved()
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodeWithSelector(
+            IApplicationWithdrawal.AccountsDriveMerkleRootAlreadyProved.selector
+        );
+    }
+
+    function _encodeAccountsDriveMerkleRootNotProved()
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodeWithSelector(
+            IApplicationWithdrawal.AccountsDriveMerkleRootNotProved.selector
+        );
+    }
+
     function _encodeInvalidMachineMerkleRoot(bytes32 machineMerkleRoot)
         internal
         pure
@@ -1149,6 +1288,17 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
     {
         return abi.encodeWithSelector(
             IApplicationWithdrawal.InvalidMachineMerkleRoot.selector, machineMerkleRoot
+        );
+    }
+
+    function _encodeInvalidAccountsDriveMerkleRoot(bytes32 accountsDriveMerkleRoot)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodeWithSelector(
+            IApplicationWithdrawal.InvalidAccountsDriveMerkleRoot.selector,
+            accountsDriveMerkleRoot
         );
     }
 
@@ -1523,14 +1673,25 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
         }
     }
 
-    function _validateAccounts() internal view {
+    function _validateAccounts(bool expectError, bytes memory expectedError) internal {
         for (uint256 i; i < _accountNames.length; ++i) {
             string memory name = _accountNames[i];
             bytes memory account = _getAccount(name);
             bytes32 accountMerkleRoot = LibEmulator.getAccountMerkleRoot(account);
             AccountValidityProof memory proof = _getAccountValidityProof(name);
+            if (expectError) vm.expectRevert(expectedError);
             _appContract.validateAccountMerkleRoot(accountMerkleRoot, proof);
+            if (expectError) vm.expectRevert(expectedError);
             _appContract.validateAccount(account, proof);
         }
+    }
+
+    function _validateAccounts(bytes memory expectedError) internal {
+        _validateAccounts(true, expectedError);
+    }
+
+    function _validateAccounts() internal {
+        bytes memory expectedError;
+        _validateAccounts(false, expectedError);
     }
 }

--- a/test/dapp/ApplicationFactory.t.sol
+++ b/test/dapp/ApplicationFactory.t.sol
@@ -288,6 +288,14 @@ contract ApplicationFactoryTest is Test, VersionGetterTestUtils {
             withdrawalConfig.isValid(), true, "Expected withdrawal config to be valid"
         );
         assertEq(appContract.isForeclosed(), false, "isForeclosed() != false");
+        {
+            bool wasAccountsDriveMerkleRootProved;
+            (wasAccountsDriveMerkleRootProved,) = appContract.getAccountsDriveMerkleRoot();
+            assertFalse(
+                wasAccountsDriveMerkleRootProved,
+                "initially, getAccountsDriveMerkleRoot() = (false, _)"
+            );
+        }
     }
 
     function _testNewApplicationFailure(

--- a/test/util/LibEmulator.sol
+++ b/test/util/LibEmulator.sol
@@ -112,14 +112,14 @@ library LibEmulator {
         return state.accounts[AccountIndex.unwrap(accountIndex)];
     }
 
-    function getAccountValidityProof(
-        State storage state,
-        ProofComponents memory pc,
-        AccountIndex accountIndex
-    ) internal view returns (AccountValidityProof memory) {
+    function getAccountValidityProof(State storage state, AccountIndex accountIndex)
+        internal
+        view
+        returns (AccountValidityProof memory)
+    {
         return AccountValidityProof({
             accountIndex: AccountIndex.unwrap(accountIndex),
-            accountRootSiblings: getAccountRootSiblings(state, pc, accountIndex)
+            accountRootSiblings: getAccountRootSiblings(state, accountIndex)
         });
     }
 
@@ -181,7 +181,7 @@ library LibEmulator {
 
         require(
             outputsMerkleRootProof.length == CanonicalMachine.MEMORY_TREE_HEIGHT,
-            "unexpected outputs Merkle proof length"
+            "unexpected outputs Merkle root proof length"
         );
     }
 
@@ -197,14 +197,11 @@ library LibEmulator {
             );
     }
 
-    function getAccountRootSiblings(
-        State storage state,
-        ProofComponents memory pc,
-        AccountIndex accountIndex
-    ) internal view returns (bytes32[] memory accountRootSiblings) {
-        bytes32[] memory forkNodeChildSibling = new bytes32[](1);
-        forkNodeChildSibling[0] = pc.forkNodeLeftChild;
-
+    function getAccountRootSiblings(State storage state, AccountIndex accountIndex)
+        internal
+        view
+        returns (bytes32[] memory accountRootSiblings)
+    {
         bytes32[] memory accountMerkleRootSiblingsInDrive =
             getAccountMerkleRootSiblingsInDrive(
                 getAccountMerkleRoots(state), AccountIndex.unwrap(accountIndex)
@@ -215,11 +212,22 @@ library LibEmulator {
             "unexpected account Merkle root siblings in drive proof length"
         );
 
+        return accountMerkleRootSiblingsInDrive;
+    }
+
+    function getAccountsDriveMerkleRootProof(ProofComponents memory pc)
+        internal
+        pure
+        returns (bytes32[] memory accountsDriveMerkleRootProof)
+    {
+        bytes32[] memory forkNodeChildSibling = new bytes32[](1);
+        forkNodeChildSibling[0] = pc.forkNodeLeftChild;
+
         require(
             pc.accountsDriveMerkleRootSiblings.length
                 == (FORK_NODE_HEIGHT - 1 - LOG2_MAX_NUM_OF_ACCOUNTS
                         - LOG2_LEAVES_PER_ACCOUNT),
-            "unexpected fork node siblings length"
+            "unexpected accounts drive Merkle root siblings length"
         );
 
         require(
@@ -238,14 +246,13 @@ library LibEmulator {
             "unexpected fork node siblings length"
         );
 
-        accountRootSiblings = accountMerkleRootSiblingsInDrive.concat(
-                pc.accountsDriveMerkleRootSiblings
-            ).concat(forkNodeChildSibling).concat(pc.forkNodeSiblings);
+        accountsDriveMerkleRootProof = pc.accountsDriveMerkleRootSiblings
+            .concat(forkNodeChildSibling).concat(pc.forkNodeSiblings);
 
         require(
-            accountRootSiblings.length
-                == (CanonicalMachine.MEMORY_TREE_HEIGHT - LOG2_LEAVES_PER_ACCOUNT),
-            "unexpected account root siblings length"
+            accountsDriveMerkleRootProof.length + getAccountsDriveRootNodeHeight()
+                == CanonicalMachine.MEMORY_TREE_HEIGHT,
+            "unexpected accounts drive Merkle root proof length"
         );
     }
 


### PR DESCRIPTION
## Summary

Currently, users need to prove their accounts through a full account-root-to-machine-root proof. However, we can split the account validation process into two steps: First, after the app is foreclosed, the accounts-drive Merkle root is proved against the last-finalized machine Merkle root. Second, accounts are validated based on the previously proved Merkle root of the accounts drive. The second proof is the one provided by the user, and should be much smaller than the whole account-root-to-machine-root proof. For example, for a hypothetical application that aims to support $2^{17}$ [USD accounts], the length of the account validity proof provided by the user would drop from 59 [^a] to 17 [^b], a 3.5x reduction. This reduces gas costs for users, but also enables slimmer withdrawal web UIs, as only the account recovery state file is required, and not the whole machine (assuming someone has altruistically proved the accounts-drive Merkle root).

This PR resolves #507.

## Note to reviewers

This PR attempts to make as few changes to the core contracts as possible, to make reviewing easier and reduce the likelihood of code defects. Tests were added to cover the additions and changes to the core contracts. As a suggestion, you can start reviewing the source contract changes, and then proceed to the test adaptations.

[USD accounts]: https://github.com/cartesi/rollups-contracts/blob/d7db66936779e7f9b53d12201a4dcccfae606c9f/src/library/LibUsdAccount.sol

[^a]: The machine Merkle tree height (59) minus log2 of the number of leaves per account (in this example, 0)
[^b]: The log2 of the maximum number of accounts (in this example, 17)