### PR TITLE
Fix Quorum not reverting with `NotFirstClaim` on claim resubmission

### DIFF
--- a/.changeset/tricky-dryers-brake.md
+++ b/.changeset/tricky-dryers-brake.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": patch
+---
+
+Fix Quorum not reverting with `NotFirstClaim` on claim resubmission

--- a/src/consensus/quorum/Quorum.sol
+++ b/src/consensus/quorum/Quorum.sol
@@ -92,37 +92,34 @@ contract Quorum is IQuorum, AbstractConsensus {
 
         Votes storage allVotes = _getAllVotes(appContract, lastProcessedBlockNumber);
 
-        // Skip if validator already voted for the same exact claim before
-        if (!votes.inFavorById.get(id)) {
-            // Revert if validator has submitted another claim for the same epoch
-            require(
-                !allVotes.inFavorById.get(id),
-                NotFirstClaim(appContract, lastProcessedBlockNumber)
-            );
+        // Revert if the validator has already voted in favor of any claim in the epoch.
+        require(
+            !allVotes.inFavorById.get(id),
+            NotFirstClaim(appContract, lastProcessedBlockNumber)
+        );
 
-            _submitClaim(
-                msg.sender,
+        _submitClaim(
+            msg.sender,
+            appContract,
+            lastProcessedBlockNumber,
+            outputsMerkleRoot,
+            machineMerkleRoot
+        );
+
+        // Register vote (for any claim in the epoch)
+        allVotes.inFavorById.set(id);
+        ++allVotes.inFavorCount;
+
+        // Register vote (for the specific claim)
+        // and stage the claim if a majority has been reached
+        votes.inFavorById.set(id);
+        if (++votes.inFavorCount == 1 + NUM_OF_VALIDATORS / 2) {
+            _stageClaim(
                 appContract,
                 lastProcessedBlockNumber,
                 outputsMerkleRoot,
                 machineMerkleRoot
             );
-
-            // Register vote (for any claim in the epoch)
-            allVotes.inFavorById.set(id);
-            ++allVotes.inFavorCount;
-
-            // Register vote (for the specific claim)
-            // and stage the claim if a majority has been reached
-            votes.inFavorById.set(id);
-            if (++votes.inFavorCount == 1 + NUM_OF_VALIDATORS / 2) {
-                _stageClaim(
-                    appContract,
-                    lastProcessedBlockNumber,
-                    outputsMerkleRoot,
-                    machineMerkleRoot
-                );
-            }
         }
     }
 

--- a/test/consensus/quorum/QuorumFactory.t.sol
+++ b/test/consensus/quorum/QuorumFactory.t.sol
@@ -829,46 +829,15 @@ contract QuorumFactoryTest is
                     "Validator shouldn't be in favor of claim for other apps"
                 );
 
-                vm.recordLogs();
-
+                vm.expectRevert(
+                    abi.encodeWithSelector(
+                        IConsensus.NotFirstClaim.selector,
+                        appContract,
+                        lastProcessedBlockNumber
+                    )
+                );
                 vm.prank(validator);
                 quorum.submitClaim(claim);
-
-                assertEq(
-                    vm.getRecordedLogs().length,
-                    0,
-                    "submitClaim() expected to emit 0 events on subsequent call"
-                );
-
-                assertEq(
-                    quorum.numOfValidatorsInFavorOfAnyClaimInEpoch(
-                        appContract, lastProcessedBlockNumber
-                    ),
-                    numOfValidatorsInFavorOfAnyClaimInEpochBefore + 1,
-                    "Number of validators in favor of any claim in epoch should be incremented"
-                );
-
-                assertTrue(
-                    quorum.isValidatorInFavorOfAnyClaimInEpoch(
-                        appContract, lastProcessedBlockNumber, id
-                    ),
-                    "Expected validator to be in favor of any claim in epoch"
-                );
-
-                assertEq(
-                    quorum.numOfValidatorsInFavorOf(
-                        appContract, lastProcessedBlockNumber, machineMerkleRoot
-                    ),
-                    numOfValidatorsInFavorOfClaimBefore + 1,
-                    "Number of validators in favor of claim should be incremented"
-                );
-
-                assertTrue(
-                    quorum.isValidatorInFavorOf(
-                        appContract, lastProcessedBlockNumber, machineMerkleRoot, id
-                    ),
-                    "Expected validator to be in favor of claim"
-                );
             }
 
             if (!wasEpochStaged) {


### PR DESCRIPTION
Currently, when a validators resubmits a claim to Quorum, the call is as a no-op. This differs from Authority, which reverts with a `NotFirstClaim` error. This PR makes Quorum behave like Authority in this aspect, so that the node tests don't need special treatment for Quorum.

Closes #495