### PR TITLE
Disable app owner privileges upon foreclosure

### DIFF
--- a/.changeset/wicked-rocks-retire.md
+++ b/.changeset/wicked-rocks-retire.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": major
+---
+
+Disable app owner privileges (consensus migration) after foreclosure

--- a/src/common/WithdrawalConfig.sol
+++ b/src/common/WithdrawalConfig.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.8;
 import {IWithdrawalOutputBuilder} from "../withdrawal/IWithdrawalOutputBuilder.sol";
 
 // @notice Withdrawal configuration parameters.
-// @param guardian The address of the account with guardian priviledges
+// @param guardian The address of the account with guardian privileges
 // @param log2LeavesPerAccount The base-2 log of leaves per account
 // @param log2MaxNumOfAccounts The base-2 log of max. num. of accounts
 // @param accountsDriveStartIndex The offset of the accounts drive

--- a/src/dapp/Application.sol
+++ b/src/dapp/Application.sol
@@ -236,6 +236,7 @@ contract Application is
         external
         override
         onlyOwner
+        notForeclosed
     {
         _outputsMerkleRootValidator = newOutputsMerkleRootValidator;
         emit OutputsMerkleRootValidatorChanged(newOutputsMerkleRootValidator);
@@ -433,6 +434,11 @@ contract Application is
         _;
     }
 
+    modifier notForeclosed() {
+        _ensureAppIsNotForeclosed();
+        _;
+    }
+
     modifier onlyForeclosed() {
         _ensureAppIsForeclosed();
         _;
@@ -534,6 +540,11 @@ contract Application is
     /// @notice Ensures the message sender is the guardian.
     function _ensureMsgSenderIsGuardian() internal view {
         require(msg.sender == getGuardian(), NotGuardian());
+    }
+
+    /// @notice Ensures the application is not foreclosed.
+    function _ensureAppIsNotForeclosed() internal view {
+        require(!isForeclosed(), Foreclosed());
     }
 
     /// @notice Ensures the application is foreclosed.

--- a/src/dapp/IApplication.sol
+++ b/src/dapp/IApplication.sol
@@ -66,11 +66,16 @@ interface IApplication is
     /// @notice Raised when the computed outputs Merkle root is invalid, according to the current outputs Merkle root validator.
     error InvalidOutputsMerkleRoot(bytes32 outputsMerkleRoot);
 
+    /// @notice Raised when the application has been foreclosed
+    /// and therefore some actions cannot be performed anymore.
+    error Foreclosed();
+
     // Permissioned functions
 
     /// @notice Migrate the application to a new outputs Merkle root validator.
     /// @param newOutputsMerkleRootValidator The new outputs Merkle root validator
     /// @dev Can only be called by the application owner.
+    /// May raise `OwnableUnauthorizedAccount` or `Foreclosed`.
     function migrateToOutputsMerkleRootValidator(IOutputsMerkleRootValidator newOutputsMerkleRootValidator)
         external;
 

--- a/test/dapp/Application.t.sol
+++ b/test/dapp/Application.t.sol
@@ -140,6 +140,16 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
         _appContract.migrateToOutputsMerkleRootValidator(newOutputsMerkleRootValidator);
     }
 
+    function testMigrateToOutputsMerkleRootValidatorRevertsForeclosed(IOutputsMerkleRootValidator newOutputsMerkleRootValidator)
+        external
+    {
+        vm.prank(_appContract.getGuardian());
+        _appContract.foreclose();
+        vm.prank(_appOwner);
+        vm.expectRevert(IApplication.Foreclosed.selector);
+        _appContract.migrateToOutputsMerkleRootValidator(newOutputsMerkleRootValidator);
+    }
+
     function testMigrateToOutputsMerkleRootValidator(IOutputsMerkleRootValidator newOutputsMerkleRootValidator)
         external
     {


### PR DESCRIPTION
This PR also fixes a minor typo in `WithdrawalConfig.sol`.

Closes #494.