### PR TITLE
Pass app contract address to buildWithdrawalOutput

### DIFF
--- a/.changeset/cold-otters-create.md
+++ b/.changeset/cold-otters-create.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollups": major
+---
+
+Add application contract address parameter to `buildWithdrawalOutput` function

--- a/src/dapp/Application.sol
+++ b/src/dapp/Application.sol
@@ -478,7 +478,7 @@ contract Application is
         view
         returns (bytes memory output)
     {
-        return getWithdrawalOutputBuilder().buildWithdrawalOutput(account);
+        return getWithdrawalOutputBuilder().buildWithdrawalOutput(address(this), account);
     }
 
     /// @notice Executes an output

--- a/src/withdrawal/IWithdrawalOutputBuilder.sol
+++ b/src/withdrawal/IWithdrawalOutputBuilder.sol
@@ -16,9 +16,13 @@ interface IWithdrawalOutputBuilder is IWithdrawalOutputBuilderErrors {
     /// of the withdrawal output. These state-changing constraints
     /// are already checked by the Solidity compiler when implementing
     /// this function as either view or pure.
+    /// @param appContract The application contract address
     /// @param account The input account
     /// @return output The withdrawal output
-    function buildWithdrawalOutput(bytes calldata account)
+    /// @dev The application contract address might be necessary for vouchers that
+    /// transfer assets from the application contract's account to the account owner's
+    /// account (e.g. in the case of ERC-721 and ERC-1155 transfers).
+    function buildWithdrawalOutput(address appContract, bytes calldata account)
         external
         view
         returns (bytes memory output);

--- a/src/withdrawal/UsdWithdrawalOutputBuilder.sol
+++ b/src/withdrawal/UsdWithdrawalOutputBuilder.sol
@@ -24,7 +24,7 @@ contract UsdWithdrawalOutputBuilder is IUsdWithdrawalOutputBuilder, RollupsContr
         return USD;
     }
 
-    function buildWithdrawalOutput(bytes calldata account)
+    function buildWithdrawalOutput(address, bytes calldata account)
         external
         view
         override

--- a/test/dapp/Application.t.sol
+++ b/test/dapp/Application.t.sol
@@ -22,6 +22,7 @@ import {SafeERC20Transfer} from "src/delegatecall/SafeERC20Transfer.sol";
 import {IInputBox} from "src/inputs/IInputBox.sol";
 import {InputBox} from "src/inputs/InputBox.sol";
 import {LibUsdAccount} from "src/library/LibUsdAccount.sol";
+import {IWithdrawalOutputBuilder} from "src/withdrawal/IWithdrawalOutputBuilder.sol";
 import {
     IWithdrawalOutputBuilderErrors
 } from "src/withdrawal/IWithdrawalOutputBuilderErrors.sol";
@@ -746,6 +747,14 @@ contract ApplicationTest is Test, OwnableTest, AddressGenerator, ConsensusTestUt
         vm.prank(_appContract.getGuardian());
         _appContract.foreclose();
         _proveAccountsDriveMerkleRoot();
+
+        vm.expectCall(
+            address(_withdrawalConfig.withdrawalOutputBuilder),
+            abi.encodeCall(
+                IWithdrawalOutputBuilder.buildWithdrawalOutput,
+                (address(_appContract), account)
+            )
+        );
 
         vm.recordLogs();
 

--- a/test/withdrawal/UsdWithdrawalOutputBuilderFactory.t.sol
+++ b/test/withdrawal/UsdWithdrawalOutputBuilderFactory.t.sol
@@ -112,6 +112,7 @@ contract UsdWithdrawalOutputBuilderTest is Test, VersionGetterTestUtils {
     }
 
     function testBuildWithdrawalOutput(
+        address appContract,
         IERC20 token,
         bytes32 salt,
         address user,
@@ -122,7 +123,8 @@ contract UsdWithdrawalOutputBuilderTest is Test, VersionGetterTestUtils {
         usdWithdrawalOutputBuilder = _factory.newUsdWithdrawalOutputBuilder(token, salt);
         bytes memory account = abi.encodePacked(_encodeAccount(user, balance), padding);
         assertGe(account.length, 28);
-        bytes memory output = usdWithdrawalOutputBuilder.buildWithdrawalOutput(account);
+        bytes memory output;
+        output = usdWithdrawalOutputBuilder.buildWithdrawalOutput(appContract, account);
         (bytes4 outputSelector, bytes memory outputArgs) = output.consumeBytes4();
         assertEq(outputSelector, Outputs.DelegateCallVoucher.selector);
         (address destination, bytes memory payload) =
@@ -137,13 +139,17 @@ contract UsdWithdrawalOutputBuilderTest is Test, VersionGetterTestUtils {
         assertEq(value, balance);
     }
 
-    function testBuildWithdrawalOutputReverts(IERC20 token, bytes32 salt) external {
+    function testBuildWithdrawalOutputReverts(
+        address appContract,
+        IERC20 token,
+        bytes32 salt
+    ) external {
         IUsdWithdrawalOutputBuilder usdWithdrawalOutputBuilder;
         usdWithdrawalOutputBuilder = _factory.newUsdWithdrawalOutputBuilder(token, salt);
         uint64 accountSize = uint64(vm.randomUint(0, 27));
         bytes memory account = vm.randomBytes(accountSize);
         vm.expectRevert(_encodeAccountTooShort(accountSize));
-        usdWithdrawalOutputBuilder.buildWithdrawalOutput(account);
+        usdWithdrawalOutputBuilder.buildWithdrawalOutput(appContract, account);
     }
 
     function _encodeAccount(address user, uint64 balance)


### PR DESCRIPTION
This PR doesn't impact the core contracts, but allows developers to implement their own generic account encodings, supporting ERC-721 and ERC-1155 accounts properly. This is not a theoretical use case. @lynoferraz is implementing such encoding himself, which can be used by Cartesi app developers that wish to leverage the EW feature for all the supported asset types.

Closes #508.