### PR TITLE
Distribute deterministic deployment addresses

### DIFF
--- a/.changeset/fair-toys-jam.md
+++ b/.changeset/fair-toys-jam.md
@@ -1,0 +1,8 @@
+---
+"@cartesi/rollups": minor
+---
+
+Distribute deterministic deployment addresses as `rollups-contracts-<version>-deployment-addresses.tar.gz` release artifacts.
+The tarball contains `deployments/<chain-id>/<contract>.json` files for Ethereum, Optimism, Base, and Arbitrum mainnets and their Sepolia testnets.
+Clients should check whether `eth_getCode` (or `cast code`) returns non-empty bytecode at any given address before using it.
+Devnet deployment addresses are still distributed through `rollups-contracts-<version>-anvil-<foundry-version>.tar.gz`.

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -43,6 +43,16 @@ jobs:
         env:
           FILEPATH: upload/rollups-contracts-${{ steps.extract_version.outputs.version }}-artifacts.tar.gz
 
+      - name: Simulate deployment to supported testnets and mainnets
+        run: |
+          ./script/deploy-testnets.sh
+          ./script/deploy-mainnets.sh
+
+      - name: Compress testnet and mainnet deployment simulation artifacts
+        run: tar -czf "$FILEPATH" deployments
+        env:
+          FILEPATH: upload/rollups-contracts-${{ steps.extract_version.outputs.version }}-deployment-addresses.tar.gz
+
       - name: Build devnet
         run: ./script/build-devnet.sh
 

--- a/script/deploy-mainnets.sh
+++ b/script/deploy-mainnets.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "${BASH_SOURCE%/*}/.."
+
+chain_ids=(
+    1          # Ethereum Mainnet
+    10         # OP Mainnet
+    8453       # Base Mainnet
+    42161      # Arbitrum Mainnet
+)
+
+for chain_id in "${chain_ids[@]}"
+do
+    ./script/deploy.sh --chain-id "$chain_id" "$@"
+done

--- a/script/deploy-testnets.sh
+++ b/script/deploy-testnets.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "${BASH_SOURCE%/*}/.."
+
+chain_ids=(
+    84532      # Base Sepolia
+    421614     # Arbitrum Sepolia
+    11155111   # Ethereum Sepolia
+    11155420   # OP Sepolia
+)
+
+for chain_id in "${chain_ids[@]}"
+do
+    ./script/deploy.sh --chain-id "$chain_id" "$@"
+done


### PR DESCRIPTION
This PR changes CI to produce a new artifact containing deterministic deployment addressed for all supported testnets and mainnets. This artifact can be used by `rollups-ts` and `cli` as an alternative to Cannon.