### PR TITLE
Add test USDC token

### DIFF
--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Build release artifacts
         run: make -j release-artifacts
+        env:
+          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
 
       - name: Upload assets to release on GitHub
         if: startsWith(github.ref, 'refs/tags/v')

--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ PUBLIC_CONTRACTS += SelfHostedApplicationFactory
 PUBLIC_CONTRACTS += TestFungibleToken
 PUBLIC_CONTRACTS += TestMultiToken
 PUBLIC_CONTRACTS += TestNonFungibleToken
+PUBLIC_CONTRACTS += TestUsdc
 PUBLIC_CONTRACTS += UsdWithdrawalOutputBuilderFactory
 
 FORGE_BIND_OPTS  += --select "^($(subst $(SPACE),|,$(PUBLIC_CONTRACTS)))$$"

--- a/script/CodeGeneration.s.sol
+++ b/script/CodeGeneration.s.sol
@@ -89,6 +89,7 @@ contract DeployersCodeGenerationScript is CodeGenerationScript {
         _addImport("src/devnet", "TestFungibleToken");
         _addImport("src/devnet", "TestMultiToken");
         _addImport("src/devnet", "TestNonFungibleToken");
+        _addImport("src/devnet", "TestUsdc");
         _addImport("src/inputs", "InputBox");
         _addImport("src/portals", "Erc1155BatchPortal");
         _addImport("src/portals", "Erc1155SinglePortal");
@@ -125,6 +126,7 @@ contract DeployersCodeGenerationScript is CodeGenerationScript {
             _addDeployer("TestFungibleToken", paramTypes);
             _addDeployer("TestMultiToken", paramTypes);
             _addDeployer("TestNonFungibleToken", paramTypes);
+            _addDeployer("TestUsdc", paramTypes);
             _addDeployer("Erc1155BatchPortal", paramTypes);
             _addDeployer("Erc1155SinglePortal", paramTypes);
             _addDeployer("Erc20Portal", paramTypes);

--- a/script/utils/ContractDeployers.sol
+++ b/script/utils/ContractDeployers.sol
@@ -16,6 +16,7 @@ import {SafeErc20Transfer} from "src/delegatecall/SafeErc20Transfer.sol";
 import {TestFungibleToken} from "src/devnet/TestFungibleToken.sol";
 import {TestMultiToken} from "src/devnet/TestMultiToken.sol";
 import {TestNonFungibleToken} from "src/devnet/TestNonFungibleToken.sol";
+import {TestUsdc} from "src/devnet/TestUsdc.sol";
 import {InputBox} from "src/inputs/InputBox.sol";
 import {Erc1155BatchPortal} from "src/portals/Erc1155BatchPortal.sol";
 import {Erc1155SinglePortal} from "src/portals/Erc1155SinglePortal.sol";
@@ -159,6 +160,22 @@ function deployTestNonFungibleToken() returns (TestNonFungibleToken deployment) 
         assert(address(deployment).code.length > 0);
     } else {
         deployment = TestNonFungibleToken(precomputedAddress);
+    }
+}
+
+function deployTestUsdc() returns (TestUsdc deployment) {
+    bytes32 salt;
+    bytes memory creationCode = type(TestUsdc).creationCode;
+    bytes memory encodedArgs = abi.encode();
+    bytes memory initCode = abi.encodePacked(creationCode, encodedArgs);
+    bytes32 initCodeHash = keccak256(initCode);
+    address precomputedAddress = computeAddress(salt, initCodeHash);
+    if (precomputedAddress.code.length == 0) {
+        deployment = new TestUsdc{salt: salt}();
+        assert(address(deployment) == precomputedAddress);
+        assert(address(deployment).code.length > 0);
+    } else {
+        deployment = TestUsdc(precomputedAddress);
     }
 }
 

--- a/script/utils/DevContracts.sol
+++ b/script/utils/DevContracts.sol
@@ -8,6 +8,7 @@ import {VmSafe} from "forge-std-1.9.6/src/Vm.sol";
 import {TestFungibleToken} from "src/devnet/TestFungibleToken.sol";
 import {TestMultiToken} from "src/devnet/TestMultiToken.sol";
 import {TestNonFungibleToken} from "src/devnet/TestNonFungibleToken.sol";
+import {TestUsdc} from "src/devnet/TestUsdc.sol";
 import {IUsdWithdrawalOutputBuilder} from "src/withdrawal/IUsdWithdrawalOutputBuilder.sol";
 import {UsdWithdrawalOutputBuilder} from "src/withdrawal/UsdWithdrawalOutputBuilder.sol";
 
@@ -19,6 +20,7 @@ struct Suite {
     TestFungibleToken testFungibleToken;
     TestMultiToken testMultiToken;
     TestNonFungibleToken testNonFungibleToken;
+    TestUsdc testUsdc;
     IUsdWithdrawalOutputBuilder testUsdWithdrawalOutputBuilder;
 }
 
@@ -26,15 +28,17 @@ function deploy(CoreContracts.Suite memory core) returns (Suite memory) {
     TestFungibleToken testFungibleToken = G.deployTestFungibleToken();
     TestNonFungibleToken testNonFungibleToken = G.deployTestNonFungibleToken();
     TestMultiToken testMultiToken = G.deployTestMultiToken();
+    TestUsdc testUsdc = G.deployTestUsdc();
     IUsdWithdrawalOutputBuilder testUsdWithdrawalOutputBuilder =
         G.deployUsdWithdrawalOutputBuilder(
-            core.usdWithdrawalOutputBuilderFactory, testFungibleToken
+            core.usdWithdrawalOutputBuilderFactory, testUsdc
         );
 
     return Suite({
         testFungibleToken: testFungibleToken,
         testMultiToken: testMultiToken,
         testNonFungibleToken: testNonFungibleToken,
+        testUsdc: testUsdc,
         testUsdWithdrawalOutputBuilder: testUsdWithdrawalOutputBuilder
     });
 }
@@ -45,6 +49,7 @@ function store(VmSafe vmSafe, Suite memory s) {
     storeDeployment(
         vmSafe, type(TestNonFungibleToken).name, address(s.testNonFungibleToken)
     );
+    storeDeployment(vmSafe, type(TestUsdc).name, address(s.testUsdc));
     storeDeployment(
         vmSafe,
         string.concat("Test", type(UsdWithdrawalOutputBuilder).name),

--- a/src/devnet/BaseTestFungibleToken.sol
+++ b/src/devnet/BaseTestFungibleToken.sol
@@ -1,0 +1,29 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+pragma solidity ^0.8.30;
+
+import {ERC20} from "@openzeppelin-contracts-5.2.0/token/ERC20/ERC20.sol";
+
+abstract contract BaseTestFungibleToken is ERC20 {
+    /// @notice Mint fungible tokens for oneself.
+    /// @param value The amount of fungible tokens to mint
+    function mint(uint256 value) external {
+        _mint(msg.sender, value);
+    }
+
+    /// @notice Mint fungible tokens.
+    /// @param to The account that will receive the tokens
+    /// @param value The amount of fungible tokens to mint
+    /// @dev Compatible with `cast erc20 mint <TOKEN> <TO> <VALUE>`.
+    function mint(address to, uint256 value) external {
+        _mint(to, value);
+    }
+
+    /// @notice Burn fungible tokens from one's balance.
+    /// @param value The amount of fungible tokens to burn
+    /// @dev Compatible with `cast erc20 burn <TOKEN> <VALUE>`.
+    function burn(uint256 value) external {
+        _burn(msg.sender, value);
+    }
+}

--- a/src/devnet/TestFungibleToken.sol
+++ b/src/devnet/TestFungibleToken.sol
@@ -5,27 +5,8 @@ pragma solidity ^0.8.30;
 
 import {ERC20} from "@openzeppelin-contracts-5.2.0/token/ERC20/ERC20.sol";
 
-contract TestFungibleToken is ERC20 {
+import {BaseTestFungibleToken} from "./BaseTestFungibleToken.sol";
+
+contract TestFungibleToken is BaseTestFungibleToken {
     constructor() ERC20("Fungible", "FUN") {}
-
-    /// @notice Mint fungible tokens for oneself.
-    /// @param value The amount of fungible tokens to mint
-    function mint(uint256 value) external {
-        _mint(msg.sender, value);
-    }
-
-    /// @notice Mint fungible tokens.
-    /// @param to The account that will receive the tokens
-    /// @param value The amount of fungible tokens to mint
-    /// @dev Compatible with `cast erc20 mint <TOKEN> <TO> <VALUE>`.
-    function mint(address to, uint256 value) external {
-        _mint(to, value);
-    }
-
-    /// @notice Burn fungible tokens from one's balance.
-    /// @param value The amount of fungible tokens to burn
-    /// @dev Compatible with `cast erc20 burn <TOKEN> <VALUE>`.
-    function burn(uint256 value) external {
-        _burn(msg.sender, value);
-    }
 }

--- a/src/devnet/TestUsdc.sol
+++ b/src/devnet/TestUsdc.sol
@@ -1,0 +1,19 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+pragma solidity ^0.8.30;
+
+import {ERC20} from "@openzeppelin-contracts-5.2.0/token/ERC20/ERC20.sol";
+
+import {BaseTestFungibleToken} from "./BaseTestFungibleToken.sol";
+
+contract TestUsdc is ERC20, BaseTestFungibleToken {
+    constructor() ERC20("USD Coin", "USDC") {}
+
+    /// @inheritdoc ERC20
+    /// @dev Overrides the default value of 18 from OpenZeppelin
+    /// to better simulate the original USDC token on front-ends.
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+}

--- a/test/dapp/Application.t.sol
+++ b/test/dapp/Application.t.sol
@@ -600,7 +600,7 @@ contract ApplicationTest is
         AccountValidityProof memory proof = _getAccountValidityProof(name);
 
         uint256 balance = vm.randomUint(amount, type(uint256).max);
-        _contracts.dev.testFungibleToken.mint(address(_appContract), balance);
+        _contracts.dev.testUsdc.mint(address(_appContract), balance);
 
         vm.expectRevert(IApplication.NotForeclosed.selector);
 
@@ -615,13 +615,13 @@ contract ApplicationTest is
         AccountValidityProof memory proof = _getAccountValidityProof(name);
 
         uint256 balance = vm.randomUint(0, amount - 1);
-        _contracts.dev.testFungibleToken.mint(address(_appContract), balance);
+        _contracts.dev.testUsdc.mint(address(_appContract), balance);
 
         vm.prank(_appContract.getGuardian());
         _appContract.foreclose();
         _proveAccountsDriveMerkleRoot();
 
-        vm.expectRevert(_encodeErc20InsufficientBalance(_erc20Token, amount));
+        vm.expectRevert(_encodeErc20InsufficientBalance(_contracts.dev.testUsdc, amount));
 
         vm.prank(vm.randomAddress());
         _appContract.withdraw(account, proof);
@@ -634,10 +634,12 @@ contract ApplicationTest is
         AccountValidityProof memory proof = _getAccountValidityProof(name);
 
         uint256 balance = vm.randomUint(amount, type(uint256).max);
-        _contracts.dev.testFungibleToken.mint(address(_appContract), balance);
+        _contracts.dev.testUsdc.mint(address(_appContract), balance);
 
         vm.mockCallRevert(
-            address(_erc20Token), abi.encodeCall(IERC20.transfer, (user, amount)), error
+            address(_contracts.dev.testUsdc),
+            abi.encodeCall(IERC20.transfer, (user, amount)),
+            error
         );
 
         vm.prank(_appContract.getGuardian());
@@ -659,10 +661,10 @@ contract ApplicationTest is
         AccountValidityProof memory proof = _getAccountValidityProof(name);
 
         uint256 balance = vm.randomUint(amount, type(uint256).max);
-        _contracts.dev.testFungibleToken.mint(address(_appContract), balance);
+        _contracts.dev.testUsdc.mint(address(_appContract), balance);
 
         vm.mockCall(
-            address(_erc20Token),
+            address(_contracts.dev.testUsdc),
             abi.encodeCall(IERC20.transfer, (user, amount)),
             abi.encode(returnValue)
         );
@@ -671,7 +673,7 @@ contract ApplicationTest is
         _appContract.foreclose();
         _proveAccountsDriveMerkleRoot();
 
-        vm.expectRevert(_encodeSafeErc20FailedOperation(address(_erc20Token)));
+        vm.expectRevert(_encodeSafeErc20FailedOperation(address(_contracts.dev.testUsdc)));
 
         vm.prank(vm.randomAddress());
         _appContract.withdraw(account, proof);
@@ -682,13 +684,13 @@ contract ApplicationTest is
         bytes memory account = _getAccount(name);
         AccountValidityProof memory proof = _getAccountValidityProof(name);
 
-        vm.etch(address(_erc20Token), abi.encode());
+        vm.etch(address(_contracts.dev.testUsdc), abi.encode());
 
         vm.prank(_appContract.getGuardian());
         _appContract.foreclose();
         _proveAccountsDriveMerkleRoot();
 
-        vm.expectRevert(_encodeSafeErc20FailedOperation(address(_erc20Token)));
+        vm.expectRevert(_encodeSafeErc20FailedOperation(address(_contracts.dev.testUsdc)));
 
         vm.prank(vm.randomAddress());
         _appContract.withdraw(account, proof);
@@ -701,7 +703,7 @@ contract ApplicationTest is
         AccountValidityProof memory proof = _getAccountValidityProof(name);
 
         // Give the app a random ERC-20 token balance
-        _contracts.dev.testFungibleToken.mint(address(_appContract), vm.randomUint());
+        _contracts.dev.testUsdc.mint(address(_appContract), vm.randomUint());
 
         vm.prank(_appContract.getGuardian());
         _appContract.foreclose();
@@ -771,10 +773,10 @@ contract ApplicationTest is
         AccountValidityProof memory proof = _getAccountValidityProof(name);
 
         uint256 appBalance = vm.randomUint(amount, type(uint256).max);
-        _contracts.dev.testFungibleToken.mint(address(_appContract), appBalance);
+        _contracts.dev.testUsdc.mint(address(_appContract), appBalance);
 
         uint256 userBalance = vm.randomUint(0, type(uint256).max - appBalance);
-        _contracts.dev.testFungibleToken.mint(user, userBalance);
+        _contracts.dev.testUsdc.mint(user, userBalance);
 
         uint256 numOfWithdrawalsBefore = _appContract.getNumberOfWithdrawals();
 
@@ -823,7 +825,7 @@ contract ApplicationTest is
                 } else {
                     revert UnexpectedLog(log);
                 }
-            } else if (log.emitter == address(_erc20Token)) {
+            } else if (log.emitter == address(_contracts.dev.testUsdc)) {
                 assertGe(log.topics.length, 1);
                 bytes32 topic0 = log.topics[0];
                 if (topic0 == IERC20.Transfer.selector) {
@@ -856,15 +858,17 @@ contract ApplicationTest is
             assertEq(funcsel2, ISafeErc20Transfer.safeTransfer.selector);
             (address token, address to, uint256 value) =
                 abi.decode(callargs2, (address, address, uint256));
-            assertEq(token, address(_erc20Token));
+            assertEq(token, address(_contracts.dev.testUsdc));
             assertEq(to, user);
             assertEq(value, amount);
         }
 
         assertEq(_appContract.getNumberOfWithdrawals(), numOfWithdrawalsBefore + 1);
         assertTrue(_appContract.wereAccountFundsWithdrawn(proof.accountIndex));
-        assertEq(_erc20Token.balanceOf(address(_appContract)), appBalance - amount);
-        assertEq(_erc20Token.balanceOf(user), userBalance + amount);
+        assertEq(
+            _contracts.dev.testUsdc.balanceOf(address(_appContract)), appBalance - amount
+        );
+        assertEq(_contracts.dev.testUsdc.balanceOf(user), userBalance + amount);
 
         {
             uint64 otherAccountIndex;


### PR DESCRIPTION
Changes:

- Add `TestUsdc` contract, an ERC-20 token contract with 6 decimal places, similar to USDC
- Deploy `TestUsdc` to devnet
- Deploy `TestUsdWithdrawalOutputBuilder` with `TestUsdc` (instead of `TestFungibleToken`)
- Adjust tests (use `TestUsdc` instead of `TestFungibleToken` for EW-related stuff)

Closes #543

Note for @vfusco: This might require some changes the rollups-node EW integration tests, because we'll use this test USDC rather than the test fungible token in the test USD withdrawal output builder contract deployed to devnet.