### PR TITLE
Add `verify-*` Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,8 @@
 .PHONY: codegen
 .PHONY: coverage
 .PHONY: deploy-all
-.PHONY: deploy-arb-mainnet
-.PHONY: deploy-arb-sepolia
-.PHONY: deploy-base-mainnet
-.PHONY: deploy-base-sepolia
-.PHONY: deploy-eth-mainnet
-.PHONY: deploy-eth-sepolia
 .PHONY: deploy-livenets
 .PHONY: deploy-mainnets
-.PHONY: deploy-opt-mainnet
-.PHONY: deploy-opt-sepolia
 .PHONY: deploy-testnets
 .PHONY: devnet
 .PHONY: install-foundry
@@ -20,6 +12,9 @@
 .PHONY: publish-soldeer-package
 .PHONY: release-artifacts
 .PHONY: rust-bindings
+.PHONY: verify-livenets
+.PHONY: verify-mainnets
+.PHONY: verify-testnets
 
 NOOP  =
 SPACE = $(NOOP) $(NOOP)
@@ -55,6 +50,7 @@ FORGE     := forge
 GENHTML   := genhtml
 
 DEPLOY_CMD := $(FORGE) script script/Deployment.s.sol:DeploymentScript
+VERIFY_CMD := $(FORGE) verify-contract --guess-constructor-args --watch
 
 ANVIL_RPC_URL := http://127.0.0.1:8545
 ANVIL_PK      := 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
@@ -99,51 +95,38 @@ export ETH_SEPOLIA_RPC_URL
 export OPT_MAINNET_RPC_URL
 export OPT_SEPOLIA_RPC_URL
 
-ANVIL_CHAIN_ID         := 31337
-ARB_MAINNET_CHAIN_ID   := 42161
-ARB_SEPOLIA_CHAIN_ID   := 421614
-BASE_MAINNET_CHAIN_ID  := 8453
-BASE_SEPOLIA_CHAIN_ID  := 84532
-ETH_MAINNET_CHAIN_ID   := 1
-ETH_SEPOLIA_CHAIN_ID   := 11155111
-OPT_MAINNET_CHAIN_ID   := 10
-OPT_SEPOLIA_CHAIN_ID   := 11155420
+TESTNETS := arb-sepolia base-sepolia eth-sepolia opt-sepolia
+MAINNETS := arb-mainnet base-mainnet eth-mainnet opt-mainnet
+LIVENETS := $(TESTNETS) $(MAINNETS)
 
-ARB_MAINNET_DEPLOY_OPTS   += --rpc-url arb_mainnet
-ARB_MAINNET_DEPLOY_OPTS   += --chain-id $(ARB_MAINNET_CHAIN_ID)
+LABEL.arb-mainnet     := Arbitrum Mainnet
+LABEL.arb-sepolia     := Arbitrum Sepolia
+LABEL.base-mainnet    := Base Mainnet
+LABEL.base-sepolia    := Base Sepolia
+LABEL.eth-mainnet     := Ethereum Mainnet
+LABEL.eth-sepolia     := Ethereum Sepolia
+LABEL.opt-mainnet     := OP Mainnet
+LABEL.opt-sepolia     := OP Sepolia
 
-ARB_SEPOLIA_DEPLOY_OPTS   += --rpc-url arb_sepolia
-ARB_SEPOLIA_DEPLOY_OPTS   += --chain-id $(ARB_SEPOLIA_CHAIN_ID)
+CHAIN_ID.anvil        := 31337
+CHAIN_ID.arb-mainnet  := 42161
+CHAIN_ID.arb-sepolia  := 421614
+CHAIN_ID.base-mainnet := 8453
+CHAIN_ID.base-sepolia := 84532
+CHAIN_ID.eth-mainnet  := 1
+CHAIN_ID.eth-sepolia  := 11155111
+CHAIN_ID.opt-mainnet  := 10
+CHAIN_ID.opt-sepolia  := 11155420
 
-BASE_MAINNET_DEPLOY_OPTS  += --rpc-url base_mainnet
-BASE_MAINNET_DEPLOY_OPTS  += --chain-id $(BASE_MAINNET_CHAIN_ID)
+TESTNET_CHAIN_IDS := $(foreach n,$(TESTNETS),$(CHAIN_ID.$(n)))
+MAINNET_CHAIN_IDS := $(foreach n,$(MAINNETS),$(CHAIN_ID.$(n)))
+LIVENET_CHAIN_IDS := $(TESTNET_CHAIN_IDS) $(MAINNET_CHAIN_IDS)
 
-BASE_SEPOLIA_DEPLOY_OPTS  += --rpc-url base_sepolia
-BASE_SEPOLIA_DEPLOY_OPTS  += --chain-id $(BASE_SEPOLIA_CHAIN_ID)
-
-ETH_MAINNET_DEPLOY_OPTS   += --rpc-url eth_mainnet
-ETH_MAINNET_DEPLOY_OPTS   += --chain-id $(ETH_MAINNET_CHAIN_ID)
-
-ETH_SEPOLIA_DEPLOY_OPTS   += --rpc-url eth_sepolia
-ETH_SEPOLIA_DEPLOY_OPTS   += --chain-id $(ETH_SEPOLIA_CHAIN_ID)
-
-OPT_MAINNET_DEPLOY_OPTS   += --rpc-url opt_mainnet
-OPT_MAINNET_DEPLOY_OPTS   += --chain-id $(OPT_MAINNET_CHAIN_ID)
-
-OPT_SEPOLIA_DEPLOY_OPTS   += --rpc-url opt_sepolia
-OPT_SEPOLIA_DEPLOY_OPTS   += --chain-id $(OPT_SEPOLIA_CHAIN_ID)
-
-TESTNET_CHAIN_IDS  += $(ARB_SEPOLIA_CHAIN_ID)
-TESTNET_CHAIN_IDS  += $(BASE_SEPOLIA_CHAIN_ID)
-TESTNET_CHAIN_IDS  += $(ETH_SEPOLIA_CHAIN_ID)
-TESTNET_CHAIN_IDS  += $(OPT_SEPOLIA_CHAIN_ID)
-
-MAINNET_CHAIN_IDS  += $(ARB_MAINNET_CHAIN_ID)
-MAINNET_CHAIN_IDS  += $(BASE_MAINNET_CHAIN_ID)
-MAINNET_CHAIN_IDS  += $(ETH_MAINNET_CHAIN_ID)
-MAINNET_CHAIN_IDS  += $(OPT_MAINNET_CHAIN_ID)
-
-LIVENET_CHAIN_IDS  := $(TESTNET_CHAIN_IDS) $(MAINNET_CHAIN_IDS)
+DEPLOYMENTS_DIR          := deployments
+DEPLOYMENT_FILES         := $(shell find $(DEPLOYMENTS_DIR) -mindepth 2 -type f -name '*.json')
+DEPLOYMENTS_SUMMARY      := $(DEPLOYMENTS_DIR)/summary.txt
+DEVNET_DEPLOYMENTS_DIR   := $(DEPLOYMENTS_DIR)/$(CHAIN_ID.anvil)
+LIVENET_DEPLOYMENTS_DIRS := $(addprefix $(DEPLOYMENTS_DIR)/, $(LIVENET_CHAIN_IDS))
 
 PUBLIC_CONTRACTS += ApplicationFactory
 PUBLIC_CONTRACTS += AuthorityFactory
@@ -191,6 +174,29 @@ FORGE_BIND_OPTS  += --crate-version "$(PROJECT_VERSION)"
 FORGE_BIND_OPTS  += --crate-license "Apache-2.0"
 FORGE_BIND_OPTS  += --crate-description "Rust bindings for Cartesi Rollups contracts"
 FORGE_BIND_OPTS  += --alloy-version 2
+
+# $(1) = livenet name slug, e.g. eth-mainnet
+define LIVENET_RULES
+
+LIVENET_DEPLOY_OPTS.$(1) += --rpc-url $(subst -,_,$(1))
+LIVENET_DEPLOY_OPTS.$(1) += --chain-id $(CHAIN_ID.$(1))
+
+.PHONY: deploy-$(1) verify-$(1)
+
+deploy-$(1): build
+	@echo "🌐 Running deployment script against $(LABEL.$(1))..."
+	@$$(DEPLOY_CMD) $$(LIVENET_DEPLOY_OPTS.$(1)) $$(DEPLOY_OPTS)
+	@echo "✅ Deployment script successfully ran against $(LABEL.$(1))."
+
+verify-$(1): $$(DEPLOYMENTS_SUMMARY)
+	@echo "🔍 Verifying $(LABEL.$(1)) deployment..."
+	@awk -v "chain_id=$(CHAIN_ID.$(1))" '$$$$1 == chain_id { print $$$$3, $$$$2 }' $$< \
+		| xargs -r -n2 $$(VERIFY_CMD) $$(LIVENET_DEPLOY_OPTS.$(1)) $$(VERIFY_OPTS)
+	@echo "✅ Successfully verified $(LABEL.$(1)) deployment."
+
+endef
+
+$(foreach livenet,$(LIVENETS),$(eval $(call LIVENET_RULES,$(livenet))))
 
 build:
 	@$(FORGE) build
@@ -267,61 +273,14 @@ devnet: check-foundry-version build
 		echo "❌ Anvil did not respond within a reasonable amount of time." >&2; \
 		exit 1; \
 	fi; \
-	echo "🔨 Deploying to Anvil (Chain ID: $(ANVIL_CHAIN_ID))..."; \
+	echo "🔨 Deploying to Anvil (Chain ID: $(CHAIN_ID.anvil))..."; \
 	$(DEPLOY_CMD) $(ANVIL_DEPLOY_OPTS) ; \
 	echo "✅ Successfully built Anvil devnet."
 
 deploy-livenets: deploy-testnets deploy-mainnets
 
-deploy-testnets: deploy-eth-sepolia
-deploy-testnets: deploy-opt-sepolia
-deploy-testnets: deploy-base-sepolia
-deploy-testnets: deploy-arb-sepolia
-
-deploy-mainnets: deploy-eth-mainnet
-deploy-mainnets: deploy-opt-mainnet
-deploy-mainnets: deploy-base-mainnet
-deploy-mainnets: deploy-arb-mainnet
-
-deploy-eth-sepolia: build
-	@echo "🌐 Running deployment script against Ethereum Sepolia..."
-	@$(DEPLOY_CMD) $(ETH_SEPOLIA_DEPLOY_OPTS) $(DEPLOY_OPTS)
-	@echo "✅ Deployment script successfully ran against Ethereum Sepolia."
-
-deploy-opt-sepolia: build
-	@echo "🌐 Running deployment script against OP Sepolia..."
-	@$(DEPLOY_CMD) $(OPT_SEPOLIA_DEPLOY_OPTS) $(DEPLOY_OPTS)
-	@echo "✅ Deployment script successfully ran against OP Sepolia."
-
-deploy-base-sepolia: build
-	@echo "🌐 Running deployment script against Base Sepolia..."
-	@$(DEPLOY_CMD) $(BASE_SEPOLIA_DEPLOY_OPTS) $(DEPLOY_OPTS)
-	@echo "✅ Deployment script successfully ran against Base Sepolia."
-
-deploy-arb-sepolia: build
-	@echo "🌐 Running deployment script against Arbitrum Sepolia..."
-	@$(DEPLOY_CMD) $(ARB_SEPOLIA_DEPLOY_OPTS) $(DEPLOY_OPTS)
-	@echo "✅ Deployment script successfully ran against Arbitrum Sepolia."
-
-deploy-eth-mainnet: build
-	@echo "🌐 Running deployment script against Ethereum Mainnet..."
-	@$(DEPLOY_CMD) $(ETH_MAINNET_DEPLOY_OPTS) $(DEPLOY_OPTS)
-	@echo "✅ Deployment script successfully ran against Ethereum Mainnet."
-
-deploy-opt-mainnet: build
-	@echo "🌐 Running deployment script against OP Mainnet..."
-	@$(DEPLOY_CMD) $(OPT_MAINNET_DEPLOY_OPTS) $(DEPLOY_OPTS)
-	@echo "✅ Deployment script successfully ran against OP Mainnet."
-
-deploy-base-mainnet: build
-	@echo "🌐 Running deployment script against Base Mainnet..."
-	@$(DEPLOY_CMD) $(BASE_MAINNET_DEPLOY_OPTS) $(DEPLOY_OPTS)
-	@echo "✅ Deployment script successfully ran against Base Mainnet."
-
-deploy-arb-mainnet: build
-	@echo "🌐 Running deployment script against Arbitrum Mainnet..."
-	@$(DEPLOY_CMD) $(ARB_MAINNET_DEPLOY_OPTS) $(DEPLOY_OPTS)
-	@echo "✅ Deployment script successfully ran against Arbitrum Mainnet."
+deploy-testnets: $(addprefix deploy-,$(TESTNETS))
+deploy-mainnets: $(addprefix deploy-,$(MAINNETS))
 
 check-foundry-version:
 	@set -eu; \
@@ -361,12 +320,18 @@ $(ARTIFACTS_BUNDLE): build | $(DIST)
 
 $(DEPLOYMENT_ADDRESSES_BUNDLE): deploy-livenets | $(DIST)
 	@echo "📦 Creating $@..."
-	@tar -czf $@ $(addprefix deployments/, $(LIVENET_CHAIN_IDS))
+	@tar -czf $@ $(LIVENET_DEPLOYMENTS_DIRS)
 	@echo "✅ Created $@."
 
 $(DEVNET_BUNDLE): devnet | $(DIST)
 	@echo "📦 Creating $@..."
-	@tar -czf $@ deployments/$(ANVIL_CHAIN_ID) $(ANVIL_STATE)
+	@tar -czf $@ $(DEVNET_DEPLOYMENTS_DIR) $(ANVIL_STATE)
+	@echo "✅ Created $@."
+
+$(DEPLOYMENTS_SUMMARY): $(DEPLOYMENT_FILES)
+	@echo "📦 Creating $@..."
+	@$(FORGE) script script/DeploymentSummary.s.sol:DeploymentSummaryScript
+	@sort -n $@ -o $@
 	@echo "✅ Created $@."
 
 $(DIST):
@@ -374,3 +339,7 @@ $(DIST):
 
 rust-bindings:
 	@$(FORGE) bind $(FORGE_BIND_OPTS)
+
+verify-livenets: verify-testnets verify-mainnets
+verify-testnets: $(addprefix verify-,$(TESTNETS))
+verify-mainnets: $(addprefix verify-,$(MAINNETS))

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,10 @@ the Cartesi Rollups contracts to EVM-compatible blockchains.
 ## Steps
 
 1. Make sure the correct version of Foundry is installed.
-   If necessary, consult the [Getting Started](../README.md#getting-started) section.
+
+```bash
+make check-foundry-version
+```
 
 2. Install the project dependencies through Soldeer.
 
@@ -17,6 +20,9 @@ forge soldeer install
 3. Set the `*_RPC_URL` environment variable to the JSON-RPC API entrypoint of the target chain.
    You can use a public JSON-RPC provider (e.g. from [ChainList](https://chainlist.org/))
    or a service like [Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/).
+   In the case of Alchemy, you can simply set the `ALCHEMY_API_KEY` environment variable,
+   and the Makefile will seamlessly construct and export the RPC URLs of each chain.
+   By default, the Makefile exports public RPC URLs, which may be rate-limited.
    Consult the `foundry.toml` file for environment variables names for each supported chain.
    For example, let us assume we want to deploy to Ethereum Mainnet.
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,0 +1,155 @@
+# Verification Guide
+
+This document aims to streamline the process of verifying
+the Cartesi Rollups contracts on block explorers and source-code repositories.
+
+Verification ensures a good experience on Etherscan (and equivalent explorers)
+for developers, auditors, and end users.
+Contracts can be verified at deployment time through the `--verify` option
+(see the [deployment guide](./deployment.md)),
+but verification may fail for reasons unrelated to the deployment itself.
+When that happens, the contracts are already deployed,
+and the deployment script has nothing left to broadcast.
+The `verify-*` Makefile targets described here read the deployment artifacts
+and allow the user to attempt verification again, as many times as necessary.
+
+## Supported networks
+
+| Network | Chain ID | Target |
+| :- | :- | :- |
+| Ethereum Mainnet | 1 | `verify-eth-mainnet` |
+| Ethereum Sepolia | 11155111 | `verify-eth-sepolia` |
+| OP Mainnet | 10 | `verify-opt-mainnet` |
+| OP Sepolia | 11155420 | `verify-opt-sepolia` |
+| Base Mainnet | 8453 | `verify-base-mainnet` |
+| Base Sepolia | 84532 | `verify-base-sepolia` |
+| Arbitrum Mainnet | 42161 | `verify-arb-mainnet` |
+| Arbitrum Sepolia | 421614 | `verify-arb-sepolia` |
+
+There are also three aggregate targets:
+`verify-testnets`, `verify-mainnets`,
+and `verify-livenets` (livenets being testnets and mainnets combined).
+The local devnet is not covered by any of them,
+since it is not backed by a public explorer.
+
+## Steps
+
+1. Make sure the correct version of Foundry is installed.
+
+```bash
+make check-foundry-version
+```
+
+2. Check out the same revision of the repository that was used for deployment.
+   Verification compares the bytecode compiled locally
+   with the bytecode deployed on-chain.
+   Any divergence in source code, dependency versions, compiler version
+   or compiler settings will cause verification to fail.
+   If you are verifying the contracts of a given release, check out its tag.
+
+3. Install the project dependencies through Soldeer.
+
+```bash
+forge soldeer install
+```
+
+4. Make sure the deployment artifacts of the target chain
+   are available under the `deployments/<chain-id>` directory.
+   If they are not, consult the [deployment guide](./deployment.md).
+
+5. Optionally, you may configure a custom Ethereum JSON-RPC provider.
+   Consult the [deployment guide](./deployment.md) for options.
+
+6. By default, contracts are verified on [Sourcify](https://sourcify.dev/).
+   If the `ETHERSCAN_API_KEY` environment variable is set,
+   they are verified on the Etherscan-based explorer of the target chain instead.
+   A single API key is accepted by every chain supported by the Etherscan V2 API.
+   In order to verify on both providers, run the target twice:
+   once with the variable set, and once without it.
+   Note that the variable must be exported to the environment,
+   because it is read by Forge, and not by Make.
+
+```bash
+export ETHERSCAN_API_KEY='<your-api-key>'
+```
+
+7. Initiate the verification process on the target chain.
+   Verification is attempted for every contract listed in the deployment artifacts of that chain,
+   one at a time, and the command waits for the result of each submission.
+   Verification options are passed down through the `VERIFY_OPTS` variable.
+
+```bash
+make verify-eth-mainnet
+```
+
+8. Contracts that are already verified are skipped,
+   so the targets are safe to run more than once
+   (in other words, they are idempotent just like the deployment targets).
+   If a single contract fails to verify,
+   fix the underlying cause and simply run the target again.
+
+## How it works
+
+Deployment artifacts are stored as one JSON file per contract,
+under the `deployments/<chain-id>` directory.
+In order to avoid depending on external JSON processors (such as `jq`),
+the `deployments/summary.txt` file is generated
+by the `script/DeploymentSummary.s.sol` Forge script.
+It lists every known deployment in textual form,
+with one line per contract, containing its chain ID, name and address,
+sorted numerically by chain ID and then by contract name.
+
+```
+1 ApplicationFactory 0x<address>
+1 AuthorityFactory 0x<address>
+11155111 ApplicationFactory 0x<address>
+11155111 AuthorityFactory 0x<address>
+```
+
+Each `verify-<chain>` target filters that file by chain ID with `awk`,
+and passes the resulting address and contract name pairs to `forge verify-contract`.
+Passing the contract name explicitly spares Forge from having to identify
+which artifact corresponds to the deployed bytecode.
+The constructor arguments, in turn, are extracted from the on-chain creation code
+through the `--guess-constructor-args` option.
+
+The summary file is a regular Make target,
+and is regenerated whenever a deployment artifact is newer than it.
+
+This file is also useful on its own:
+because deployments are deterministic,
+two developers working on the same release
+should be able to compare their summary files and attest no differences.
+
+## Troubleshooting
+
+### find: 'deployments': No such file or directory
+
+The `deployments` directory does not exist,
+which means there is nothing to verify.
+Please review step 4 of the [Steps](#steps) section.
+For the same reason, a `verify-<chain>` target succeeds without verifying anything
+if there are no deployment artifacts for that particular chain.
+
+### Contract source code already verified
+
+This is not an error.
+The contract had already been verified on the explorer,
+so Forge skipped it and moved on to the next one.
+
+### The deployed bytecode does not match the compiled one
+
+Verification is only possible if the local build reproduces the deployed bytecode.
+Please make sure you checked out the revision that was used for the deployment,
+that dependencies were installed with `forge soldeer install`,
+and that no compiler option was overridden.
+
+### The target chain explorer is not Etherscan-based
+
+The `verify-*` targets support Sourcify and Etherscan out of the box.
+If you need a different verification provider,
+you may override the verification command on the command line.
+
+```bash
+make verify-eth-mainnet VERIFY_OPTS="--verifier <verifier> --verifier-url <url>"
+```

--- a/script/DeploymentSummary.s.sol
+++ b/script/DeploymentSummary.s.sol
@@ -1,0 +1,65 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.30;
+
+import {Script} from "forge-std-1.9.6/src/Script.sol";
+import {VmSafe} from "forge-std-1.9.6/src/Vm.sol";
+
+contract DeploymentSummaryScript is Script {
+    function run() external {
+        string memory summary = _buildSummary();
+        vmSafe.createDir("deployments", true);
+        // forge-lint: disable-next-line(unsafe-cheatcode)
+        vmSafe.writeFile(string.concat("deployments/summary.txt"), summary);
+    }
+
+    function _buildSummary() internal view returns (string memory summary) {
+        VmSafe.DirEntry[] memory dirEntries = vmSafe.readDir("deployments", 2, false);
+        for (uint256 i; i < dirEntries.length; ++i) {
+            VmSafe.DirEntry memory dirEntry = dirEntries[i];
+            if (dirEntry.depth == 2 && _isJsonFilePath(dirEntry.path)) {
+                // forge-lint: disable-next-line(unsafe-cheatcode)
+                string memory json = vmSafe.readFile(dirEntry.path);
+                string memory contractName = vmSafe.parseJsonString(json, ".contractName");
+                address addr = vmSafe.parseJsonAddress(json, ".address");
+                string memory dirBaseName = _getFileDirBaseName(dirEntry.path);
+                uint256 chainId = vmSafe.parseUint(dirBaseName);
+                string memory summaryLine = _buildSummaryLine(chainId, contractName, addr);
+                summary = string.concat(summary, summaryLine, "\n");
+            }
+        }
+    }
+
+    /// @notice Construct a summary line (without \n) from its constituent parts.
+    function _buildSummaryLine(uint256 chainId, string memory contractName, address addr)
+        internal
+        pure
+        returns (string memory)
+    {
+        string memory chainIdStr = vmSafe.toString(chainId);
+        string memory addrStr = vmSafe.toString(addr);
+        return string.concat(chainIdStr, " ", contractName, " ", addrStr);
+    }
+
+    /// @notice Check whether a file path points to a JSON file.
+    /// @dev Checks (1) whether it is a file and (2) whether its path ends in `.json`.
+    function _isJsonFilePath(string memory path) internal view returns (bool) {
+        if (!vmSafe.isFile(path)) return false;
+        string[] memory parts = vmSafe.split(path, ".");
+        if (parts.length == 0) return false;
+        string memory ext = parts[parts.length - 1];
+        return keccak256(bytes(ext)) == keccak256("json");
+    }
+
+    /// @notice Get the directory base name of a file. Fails for root files.
+    /// @dev For example, ./deployments/11155111/InputBox.json --> 11155111
+    function _getFileDirBaseName(string memory path)
+        internal
+        pure
+        returns (string memory)
+    {
+        string[] memory parts = vmSafe.split(path, "/");
+        return parts[parts.length - 2];
+    }
+}


### PR DESCRIPTION
Changes:

- Add a `verify-<chain>` target for every supported livenet, which reads the deployment artifacts of that chain and verifies its contracts through `forge verify-contract` (on Sourcify by default, or on the chain's Etherscan-based explorer if `ETHERSCAN_API_KEY` is set)
- Add aggregate `verify-testnets`, `verify-mainnets` and `verify-livenets` targets
- Add `VERIFY_OPTS`, counterpart of `DEPLOY_OPTS`
- Add a `DeploymentSummary` Forge script, which writes one deployment per line to `deployments/summary.txt` (chain ID, contract name and address), filtered per chain with `awk`
- Generate the `deploy-*` and `verify-*` recipes with GNU Make macros
- Add `docs/verification.md`, and update `docs/deployment.md`

Tested against all Sepolia-based tests.
You can review it too by running the `{deploy,verify}-testnets` targets on your side.
Since all contracts were deployed and verified, these targets will succeed silently.

If you want to test fresh deployment and verification, make dummy changes to source code (e.g. change the project version on the Makefile and run `make codegen`; this will affect all contracts that are deployed to livenets).

Closes #548