### PR TITLE
Override file permissions when creating archives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,7 @@ TAR_DETERMINISTIC_CREATE_OPTS += --mtime=@0
 TAR_DETERMINISTIC_CREATE_OPTS += --owner=1000
 TAR_DETERMINISTIC_CREATE_OPTS += --group=1000
 TAR_DETERMINISTIC_CREATE_OPTS += --numeric-owner
+TAR_DETERMINISTIC_CREATE_OPTS += --mode=a=rX,u+w
 
 # ------------------------------------------------------------------------------
 # Deployment artifacts


### PR DESCRIPTION
Reference: https://reproducible-builds.org/docs/archives/

Grant read permission for all, write permission for users only, and execution permission for all only if set already for anyone. This last part is important for directories, which need x to be set to be traversed. Currently, we don't bundle any executables, but the (capital) X flag ensures their execution permissions are also maintained when bundled (and therefore later extracted).

This change fixes an issue with different environments having different umask values, which impact the permissions of release artifacts before they are bundled. Unfortunately, Forge does not provide a way to override file permissions through `VmSafe.writeFile` (which is what we use to write deployment artifacts). We could override permissions after creating them or before bundling, but this is a fragile approach. We opt to override permissions as files are bundled.

This does not fix the non-determinism of Anvil devnet state dump builds, however it does seem to fix the non-determinism of deployment artifacts and compilation artifacts bundles. For the non-deterministic Anvil devnet dump state issue, I've opened https://github.com/foundry-rs/foundry/issues/16187, which seems to be progressing (https://github.com/foundry-rs/foundry/pull/16189 fixes it and is currently approved for merging). We will have to wait for a stable release of Foundry with this fix, however.